### PR TITLE
Fix README: Use id instead of uid in example query

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ You can query Document nodes created from prismic.io like the following:
   allPrismicDocument {
     edges {
       node {
-        uid
+        id
         data {
           title {
             type


### PR DESCRIPTION
Seems that ``PrismicDocument`` won't currently have property ``uid``, but there's ``id`` instead.