### PR TITLE
Remove depency on deprecated package 'crypto'.

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,6 @@
   "author": "Angelo Ashmore <angelo.ashmore@walltowall.com>",
   "license": "MIT",
   "dependencies": {
-    "crypto": "^0.0.3",
     "json-stringify-safe": "^5.0.1",
     "lodash": "^4.17.4",
     "prismic-javascript": "^1.1.5"


### PR DESCRIPTION
As documented on npm's [page](https://www.npmjs.com/package/crypto) for the `crypto` package, this package is deprecated as there is now a Node-native library. The native library happens to be API compatible (at least for the purposes of `gatsby-source-prismic` anyway) so the dependency simply had to be removed from `package.json`.