### PR TITLE
Fix typo / Add raw payload field

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
   "license": "MIT",
   "dependencies": {
     "gatsby-node-helpers": "^0.1.3",
-    "lodash": "^4.17.4",
     "prismic-javascript": "^1.1.5"
   },
   "devDependencies": {

--- a/src/gatsby-node.js
+++ b/src/gatsby-node.js
@@ -10,7 +10,7 @@ export const sourceNodes = async (
   { boundActionCreators: { createNode } },
   { repositoryName, accessToken }
 ) => {
-  const { documents } = await fetchData({ respositoryName, accessToken })
+  const { documents } = await fetchData({ repositoryName, accessToken })
 
   documents.forEach(pipe(DocumentNode, createNode))
 }

--- a/src/gatsby-node.js
+++ b/src/gatsby-node.js
@@ -1,5 +1,4 @@
 import createNodeHelpers from 'gatsby-node-helpers'
-import pipe from 'lodash/fp/pipe'
 import fetchData from './fetch'
 
 const { createNodeFactory } = createNodeHelpers({ typePrefix: `Prismic` })
@@ -12,5 +11,7 @@ export const sourceNodes = async (
 ) => {
   const { documents } = await fetchData({ repositoryName, accessToken })
 
-  documents.forEach(pipe(DocumentNode, createNode))
+  documents.forEach(document => {
+    createNode(DocumentNode(document, { raw: JSON.stringify(document) }))
+  })
 }


### PR DESCRIPTION
Hey @angeloashmore, thanks for the solid plugin. I find it easier to use the raw JSON payload from Prismic in gatsby templates instead of maintaining a crazy big graphql query. I added it here as the `raw` field.

This also fixes misspelled `repositoryName` variable passed to `fetch`. 