### PR TITLE
Fixes errors on null values

### DIFF
--- a/src/gatsby-node.js
+++ b/src/gatsby-node.js
@@ -12,6 +12,7 @@ const isRichTextField = value =>
   Object.keys(value[0]).includes('spans')
 
 const isDocumentLinkField = value =>
+  !!value &&
   typeof value === 'object' &&
   value.link_type === 'Document'
 

--- a/src/gatsby-node.js
+++ b/src/gatsby-node.js
@@ -13,6 +13,8 @@ const isRichTextField = value =>
 
 const isDocumentLinkField = value =>
   !!value &&
+  !!value.type &&
+  !!value.id &&
   typeof value === 'object' &&
   value.link_type === 'Document'
 


### PR DESCRIPTION
When checking if a value is a DocumentLinkField, a tyepof on a null value will return 'object', which makes it pass the first test. This adds an additional check on value