### PR TITLE
fetchLinks support in options

### DIFF
--- a/src/fetch.js
+++ b/src/fetch.js
@@ -1,6 +1,10 @@
 import Prismic from 'prismic-javascript'
 
-export default async ({ repositoryName, accessToken }) => {
+export default async ({
+  repositoryName,
+  accessToken,
+  fetchLinks,
+}) => {
   console.time(`Fetch Prismic data`)
   console.log(`Starting to fetch data from Prismic`)
 
@@ -8,7 +12,7 @@ export default async ({ repositoryName, accessToken }) => {
   const client = await Prismic.api(apiEndpoint, { accessToken })
 
   // Query all documents from client
-  const documents = await pagedGet(client)
+  const documents = await pagedGet(client, [], { fetchLinks })
 
   console.timeEnd(`Fetch Prismic data`)
 

--- a/src/gatsby-node.js
+++ b/src/gatsby-node.js
@@ -13,9 +13,10 @@ export const sourceNodes = async (gatsby, pluginOptions) => {
     accessToken,
     linkResolver = () => {},
     htmlSerializer = () => {},
+    fetchLinks = [],
   } = pluginOptions
 
-  const { documents } = await fetchData({ repositoryName, accessToken })
+  const { documents } = await fetchData({ repositoryName, accessToken, fetchLinks })
 
   await Promise.all(
     documents.map(async doc => {

--- a/src/gatsby-node.js
+++ b/src/gatsby-node.js
@@ -16,7 +16,11 @@ export const sourceNodes = async (gatsby, pluginOptions) => {
     fetchLinks = [],
   } = pluginOptions
 
-  const { documents } = await fetchData({ repositoryName, accessToken, fetchLinks })
+  const { documents } = await fetchData({
+    repositoryName,
+    accessToken,
+    fetchLinks,
+  })
 
   await Promise.all(
     documents.map(async doc => {


### PR DESCRIPTION
Adds the ability to specify a general-purpose array of
fetchLinks options (see https://prismic.io/docs/javascript/query-the-api/fetch-linked-document-fields)
that allows deeper access to data for linked documents.

## How to Use
in gatsby-config.js
```
...
{
  resolve: 'gatsby-source-prismic',
  options: {
    apiEndpoint: 'https://site.prismic.io/api/v2',
    repositoryName: '...',
    accessToken: '...',
    htmlSerializer: ({ node, key, value }) => {...},
    linkResolver: ({ node, key, value }) => {...},
    fetchLinks: [
      'article.topic',
      'course.module'
    ]
  }
}
...
```

in the linkResolver:
```
function linkResolver (doc) {
  if (doc.type === 'article') {
    console.log(doc.data.topic.value)
    return `/${doc.data.topic.value.document.slug}/${doc.uid}/`
    // ^ now this works! It wasn't possible to access anything passed data before,
    // so topic would be undefined.
  }

  return '/'
}
```