### PR TITLE
Added language to plugin options to globaly set Prismic content language

### DIFF
--- a/src/fetch.js
+++ b/src/fetch.js
@@ -1,6 +1,6 @@
 import Prismic from 'prismic-javascript'
 
-export default async ({ repositoryName, accessToken, fetchLinks }) => {
+export default async ({ repositoryName, accessToken, fetchLinks, lang }) => {
   console.time(`Fetch Prismic data`)
   console.log(`Starting to fetch data from Prismic`)
 
@@ -8,7 +8,7 @@ export default async ({ repositoryName, accessToken, fetchLinks }) => {
   const client = await Prismic.api(apiEndpoint, { accessToken })
 
   // Query all documents from client
-  const documents = await pagedGet(client, [], { fetchLinks })
+  const documents = await pagedGet(client, [], { fetchLinks }, lang)
 
   console.timeEnd(`Fetch Prismic data`)
 
@@ -21,13 +21,14 @@ async function pagedGet(
   client,
   query = [],
   options = {},
+  lang = '*',
   page = 1,
   pageSize = 100,
   aggregatedResponse = null,
 ) {
   const mergedOptions = Object.assign(
     {
-      lang: `*`,
+      lang,
     },
     options,
   )
@@ -49,6 +50,7 @@ async function pagedGet(
       client,
       query,
       options,
+      lang,
       page + 1,
       pageSize,
       aggregatedResponse,

--- a/src/gatsby-node.js
+++ b/src/gatsby-node.js
@@ -14,12 +14,14 @@ export const sourceNodes = async (gatsby, pluginOptions) => {
     linkResolver = () => {},
     htmlSerializer = () => {},
     fetchLinks = [],
+    lang = '*'
   } = pluginOptions
 
   const { documents } = await fetchData({
     repositoryName,
     accessToken,
     fetchLinks,
+    lang,
   })
 
   await Promise.all(


### PR DESCRIPTION
In order to make it easier to deploy a Gatsby / Prismic site in a certain language per domain (eg .de, .nl, .com etc) I added an option to set the default Prismic content language. The default language is still *.