### PR TITLE
Fix issue with touchNode warning

### DIFF
--- a/src/normalize.js
+++ b/src/normalize.js
@@ -89,7 +89,7 @@ const normalizeImageField = async args => {
   // created file node to not try to redownload.
   if (cacheMediaData) {
     fileNodeID = cacheMediaData.fileNodeID
-    touchNode(cacheMediaData.fileNodeID)
+    touchNode({ nodeId: cacheMediaData.fileNodeID})
   }
 
   // If we don't have cached data, download the file.


### PR DESCRIPTION
Fixes #54, which removes all of the following warnings that appear when running `gatsby develop`:

```
Calling "touchNode" with a nodeId is deprecated. Please pass an object containing a nodeId instead: touchNode({ nodeId: 'a-node-id' })
```