### PR TITLE
Decode Prismic images URL

### DIFF
--- a/src/normalize.js
+++ b/src/normalize.js
@@ -83,7 +83,8 @@ const normalizeLinkField = (value, linkResolver, generateNodeId) => {
 // data is provided on the `localFile` key.
 const normalizeImageField = async args => {
   const { value, createNode, createNodeId, store, cache, touchNode } = args
-  const { alt, dimensions, copyright, url, ...extraFields } = value
+  const { alt, dimensions, copyright, ...extraFields } = value
+  const url = decodeURIComponent(value.url)
 
   let fileNodeID
   const mediaDataCacheKey = `prismic-media-${url}`


### PR DESCRIPTION
Since few days Prismic API started to give images URL with an encoded character (`%2F`), for example `https://satispay-website.cdn.prismic.io/satispay-website%2Fc359fb8c-88d3-45ec-9018-1abcf5e53869_kpi-04.svg`, giving problems with the Gatsby cache.

This fix simply decodes the URL bringing it to its original state, for example: `https://satispay-website.cdn.prismic.io/satispay-website/c359fb8c-88d3-45ec-9018-1abcf5e53869_kpi-04.svg`.