### PR TITLE
Ability to make the normalization of images optional

### DIFF
--- a/src/gatsby-node.js
+++ b/src/gatsby-node.js
@@ -15,6 +15,7 @@ export const sourceNodes = async (gatsby, pluginOptions) => {
     htmlSerializer = () => {},
     fetchLinks = [],
     lang = '*',
+    normalizeImages = true,
   } = pluginOptions
 
   const { documents } = await fetchData({
@@ -39,6 +40,7 @@ export const sourceNodes = async (gatsby, pluginOptions) => {
           touchNode,
           store,
           cache,
+          normalizeImages,
         })
 
         return node

--- a/src/gatsby-node.js
+++ b/src/gatsby-node.js
@@ -15,7 +15,7 @@ export const sourceNodes = async (gatsby, pluginOptions) => {
     htmlSerializer = () => {},
     fetchLinks = [],
     lang = '*',
-    normalizeImages = true,
+    shouldNormalizeImage = () => true,
   } = pluginOptions
 
   const { documents } = await fetchData({
@@ -40,7 +40,7 @@ export const sourceNodes = async (gatsby, pluginOptions) => {
           touchNode,
           store,
           cache,
-          normalizeImages,
+          shouldNormalizeImage,
         })
 
         return node

--- a/src/normalize.js
+++ b/src/normalize.js
@@ -190,7 +190,7 @@ const normalizeGroupField = async args =>
 // of it. If the type is not supported or needs no normalizing, it is returned
 // as-is.
 export const normalizeField = async args => {
-  const { key, value, node, nodeHelpers, normalizeImages } = args
+  const { key, value, node, nodeHelpers, shouldNormalizeImage } = args
   let { linkResolver, htmlSerializer } = args
   const { generateNodeId } = nodeHelpers
 
@@ -203,7 +203,11 @@ export const normalizeField = async args => {
   if (isLinkField(value))
     return normalizeLinkField(value, linkResolver, generateNodeId)
 
-  if (normalizeImages && isImageField(value))
+  if (
+    isImageField(value) &&
+    typeof shouldNormalizeImage === 'function' &&
+    shouldNormalizeImage({ node, key, value })
+  )
     return await normalizeImageField(args)
 
   if (isSliceField(key, value)) return await normalizeSliceField(args)

--- a/src/normalize.js
+++ b/src/normalize.js
@@ -190,7 +190,7 @@ const normalizeGroupField = async args =>
 // of it. If the type is not supported or needs no normalizing, it is returned
 // as-is.
 export const normalizeField = async args => {
-  const { key, value, node, nodeHelpers } = args
+  const { key, value, node, nodeHelpers, normalizeImages } = args
   let { linkResolver, htmlSerializer } = args
   const { generateNodeId } = nodeHelpers
 
@@ -203,7 +203,8 @@ export const normalizeField = async args => {
   if (isLinkField(value))
     return normalizeLinkField(value, linkResolver, generateNodeId)
 
-  if (isImageField(value)) return await normalizeImageField(args)
+  if (normalizeImages && isImageField(value))
+    return await normalizeImageField(args)
 
   if (isSliceField(key, value)) return await normalizeSliceField(args)
 


### PR DESCRIPTION
When working with Prismic repos that have large media libraries, booting can sometimes take upwards of ten minutes or more, depending on your internet connection. This is due to the process of normalizing images during boot, in which case images are downloaded to the cache for use with gatsby-image-sharp and anything else that lets your process images.

Because this process can take a very long time, and there's no feedback when this is happening, this sometimes makes it seem like it gets stuck on the `source and transform nodes` part of booting the project. While this is happening, in one of the projects I'm working on, it downloads what seems like GBs of image data.

In cases where no local image processing is taking place, this option allows you to turn off normalization and local access to images. This is especially useful in cases where we can rely on prismic's image processing to link remotely to images.

In testing, instead waiting minutes to finish booting the project, a fresh boot from a cleared cache will take ~10s to finish the same task.