### PR TITLE
fix: falsey staticData returns previewData, throws on both falsey

### DIFF
--- a/docs/previews.md
+++ b/docs/previews.md
@@ -8,6 +8,7 @@
     - [Guide](#guide)
     - [usePrismicPreview](#useprismicpreview)
     - [mergePrismicPreviewData](#mergeprismicpreviewdata)
+    - [Previewing un-published pages](#previewing-un-published-pages)
   - [API](#api)
     - [usePrismicPreview](#useprismicpreview-1)
       - [Return Value](#return-value)
@@ -197,6 +198,10 @@ Just like last time, let's break this down:
 
 4. Now, use your merged `data` object as you normally would! Since we have the
    same key-value structure for previews, things should "just work"!
+
+### Previewing un-published pages
+
+TODO
 
 ## API
 

--- a/docs/previews.md
+++ b/docs/previews.md
@@ -14,6 +14,7 @@
     - [mergePrismicPreviewData](#mergeprismicpreviewdata-1)
       - [Return Value](#return-value-1)
         - [If `previewData` is falsey](#if-previewdata-is-falsey)
+        - [If `staticData` is falsey](#if-staticdata-is-falsey)
         - [If `previewData` and `staticData` have the same top level keys](#if-previewdata-and-staticdata-have-the-same-top-level-keys)
         - [If `previewData` and `staticData` have different top level keys](#if-previewdata-and-staticdata-have-different-top-level-keys)
   - [Limitations](#limitations)
@@ -237,7 +238,7 @@ Receives a single object as a parameter:
 
 |     Key     | Required? |  Type  | Description                                                                                                                        |
 | :---------: | :-------: | :----: | ---------------------------------------------------------------------------------------------------------------------------------- |
-| staticData  |    ✅     | Object | Static data from Gatsby. Typically this is the data that Gatsby provides to your pages from `graphql` queries via the `data` prop. |
+| staticData  |           | Object | Static data from Gatsby. Typically this is the data that Gatsby provides to your pages from `graphql` queries via the `data` prop. |
 | previewData |           | Object | Preview data from `usePrismicPreview`.                                                                                             |
 
 #### Return Value
@@ -245,6 +246,10 @@ Receives a single object as a parameter:
 ##### If `previewData` is falsey
 
 Returns `staticData` as is.
+
+##### If `staticData` is falsey
+
+Returns `previewData` as is.
 
 ##### If `previewData` and `staticData` have the same top level keys
 

--- a/docs/previews.md
+++ b/docs/previews.md
@@ -23,7 +23,7 @@
 ## Requirements
 
 Prismic previews makes use of `URLSearchParams` to read querystring parameters
-from URLs. If you need to support older browsers, we recommend polyfillying it
+from URLs. If you need to support older browsers, we recommend polyfilling it
 via:
 [`url-search-params-polyfill`](https://www.npmjs.com/package/url-search-params-polyfill)
 

--- a/docs/previews.md
+++ b/docs/previews.md
@@ -163,9 +163,10 @@ import { mergePrismicPreviewData } from 'gatsby-source-prismic'
 import { Layout } from '../components/Layout'
 
 const AuthorTemplate = ({ location, data: staticData }) => {
-  const previewData = location.state.hasOwnProperty('previewData')
-    ? JSON.parse(location.state.previewData)
-    : null
+  const previewData =
+    location.state && location.state.hasOwnProperty('previewData')
+      ? JSON.parse(location.state.previewData)
+      : null
   const data = mergePrismicPreviewData({ staticData, previewData })
 
   return (

--- a/src/__tests__/hooks.js
+++ b/src/__tests__/hooks.js
@@ -16,16 +16,31 @@ const mockFetch = data =>
   )
 
 describe('mergePrismicPreviewData', () => {
-  test('returns undefined if staticData is falsey', () => {
+  test('throws if staticData and previewData are falsey', () => {
+    expect(() =>
+      mergePrismicPreviewData({
+        staticData: undefined,
+        previewData: undefined,
+      }),
+    ).toThrow(/invalid data/i)
+  })
+
+  test('returns previewData if staticData is falsey', () => {
     expect(
-      mergePrismicPreviewData({ staticData: undefined, previewData: {} }),
-    ).toBeUndefined()
+      mergePrismicPreviewData({
+        staticData: undefined,
+        previewData: { test: 'DATA' },
+      }),
+    ).toMatchObject({ test: 'DATA' })
   })
 
   test('returns staticData if previewData is falsey', () => {
     expect(
-      mergePrismicPreviewData({ staticData: {}, previewData: undefined }),
-    ).toMatchObject({})
+      mergePrismicPreviewData({
+        staticData: { test: 'DATA' },
+        previewData: undefined,
+      }),
+    ).toMatchObject({ test: 'DATA' })
   })
 
   test('returns merged object given static and preview data with same custom type', () => {


### PR DESCRIPTION
`mergePrismicPreviewData` will now throw if both `staticData` and `previewData` are undefined, but will otherwise return the other corresponding object if one of the two are falsey.

This change allows for cleaner composition of previews on unpublished documents from Prismic.