### PR TITLE
feat: fetchPredicates, import documents with predicates

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,22 @@ plugins: [
         // Your list of links
       ],
 
+      // Set a function to import documents with Primic predicates.
+      // Only documents matching your predicates will be sourced.
+      // For each predicate in the list, a request is made in parallel.
+      // The default behavior is a single request with an empty predicate to query all documents.
+      // See: https://prismic.io/docs/javascript/query-the-api/query-predicates-reference
+      //
+      // Example:
+      // This will only the import documents of the type 'bar' OR linked to the tag 'foo'
+      //
+      // fetchPredicates: Predicates => ([
+      //   Predicates.at(document.tags, ['foo']),
+      //   Predicates.at(document.type, 'bar')
+      // ]),
+      //      
+      fetchPredicates: Predicates => ([`[]`]),
+
       // Set an HTML serializer function used to process formatted content.
       // Fields with rich text formatting use this function to generate the
       // correct HTML.

--- a/docs/previews-api.md
+++ b/docs/previews-api.md
@@ -127,4 +127,5 @@ Previews _will not_ function properly since `previewData` will not change
 
 ### Preview links
 
-Share links from Prismic Toolbar are currently unsupported. See [#276](https://github.com/angeloashmore/gatsby-source-prismic/issues/276).
+Share links from Prismic Toolbar are currently unsupported. See
+[#276](https://github.com/angeloashmore/gatsby-source-prismic/issues/276).

--- a/src/types.ts
+++ b/src/types.ts
@@ -6,6 +6,7 @@ import {
 } from 'gatsby'
 import { FixedObject, FluidObject } from 'gatsby-image'
 import { Document as PrismicDocument } from 'prismic-javascript/d.ts/documents'
+import PrismicPredicates from 'prismic-javascript/d.ts/Predicates'
 import * as PrismicDOM from 'prismic-dom'
 import { ImgixUrlParams } from 'gatsby-plugin-imgix'
 
@@ -359,6 +360,7 @@ export interface PluginOptions extends GatsbyPluginOptions {
   linkResolver?: PluginLinkResolver
   htmlSerializer?: PluginHTMLSerializer
   fetchLinks?: string[]
+  fetchPredicates?: (predicates: typeof PrismicPredicates) => string[]
   schemas: Schemas
   lang?: string
   shouldDownloadImage?: ShouldDownloadImage

--- a/src/validateOptions.ts
+++ b/src/validateOptions.ts
@@ -10,6 +10,7 @@ const baseSchema = {
   linkResolver: struct.defaulted(struct.func(), () => () => () => {}),
   htmlSerializer: struct.defaulted(struct.func(), () => () => () => {}),
   fetchLinks: struct.defaulted(struct.array(struct.string()), []),
+  fetchPredicates: struct.defaulted(struct.func(), () => () => [`[]`]),
   lang: struct.defaulted(struct.string(), '*'),
   typePathsFilenamePrefix: struct.defaulted(
     struct.string(),


### PR DESCRIPTION
In order to reduce the amount of data extracted from Prismic, I suggest adding an option to multiple fetch Prismic api with predicates.

My use-case is to have a single Prismic repository with unconcerned/unused documents.

A single fetch with predicate was not enough due to the nonexistence of an OR predicate.

@angeloashmore