### PR TITLE
Added the ability to source from a given release ID

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,13 @@ plugins: [
       // The token will be listed under "Permanent access tokens".
       accessToken: 'example-wou7evoh0eexuf6chooz2jai2qui9pae4tieph1sei4deiboj',
 
+      // The ID of the release you want to build from. Your access token must
+      // allow for access to releases. This is particularly useful for use on
+      // a staging branch for an upcoming release.
+      // The ID can be found in the URL for a given release. Example: 'abcdef'
+      // if the URL is https://my-repo.prismic.io/documents/upcoming~r=abcdef/
+      releaseId: 'abcdef',
+
       // Set a link resolver function used to process links in your content.
       // Fields with rich text formatting or links to internal content use this
       // function to generate the correct link URL.

--- a/src/fetch.js
+++ b/src/fetch.js
@@ -1,14 +1,25 @@
 import Prismic from 'prismic-javascript'
 
-export default async ({ repositoryName, accessToken, fetchLinks, lang }) => {
+export default async ({
+  repositoryName,
+  accessToken,
+  releaseId,
+  fetchLinks,
+  lang,
+}) => {
   console.time(`Fetch Prismic data`)
   console.log(`Starting to fetch data from Prismic`)
 
   const apiEndpoint = `https://${repositoryName}.prismic.io/api/v2`
   const client = await Prismic.api(apiEndpoint, { accessToken })
 
+  let ref
+  if (releaseId) {
+    ref = client.refs.find(ref => ref.id === releaseId).ref
+  }
+
   // Query all documents from client
-  const documents = await pagedGet(client, [], { fetchLinks }, lang)
+  const documents = await pagedGet(client, [], { fetchLinks }, lang, ref)
 
   console.timeEnd(`Fetch Prismic data`)
 
@@ -22,6 +33,7 @@ async function pagedGet(
   query = [],
   options = {},
   lang = '*',
+  ref = null,
   page = 1,
   pageSize = 100,
   aggregatedResponse = null,
@@ -32,6 +44,7 @@ async function pagedGet(
     ...mergedOptions,
     page,
     pageSize,
+    ref,
   })
 
   if (!aggregatedResponse) {
@@ -46,6 +59,7 @@ async function pagedGet(
       query,
       options,
       lang,
+      ref,
       page + 1,
       pageSize,
       aggregatedResponse,

--- a/src/gatsby-node.js
+++ b/src/gatsby-node.js
@@ -11,6 +11,7 @@ export const sourceNodes = async (gatsby, pluginOptions) => {
   const {
     repositoryName,
     accessToken,
+    releaseId,
     linkResolver = () => {},
     htmlSerializer = () => {},
     fetchLinks = [],
@@ -21,6 +22,7 @@ export const sourceNodes = async (gatsby, pluginOptions) => {
   const { documents } = await fetchData({
     repositoryName,
     accessToken,
+    releaseId,
     fetchLinks,
     lang,
   })


### PR DESCRIPTION
Hey!

We wanted to be able to build our Gatsby site based on a release in Prismic, so made these changes to allow that.

I opted to use the release ID and use that to pull the `ref`, as the `ref` is a moving target that changes every time you make a modification in a release. By specifying the ID, we can get the release ref from the Prismic API.

Let me know if there are any changes you would suggest and I'll be happy to make them.