### PR TITLE
[WIP]fix: use tiny-async-pool to fix parallel download crash on large repos

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "prismic-javascript": "^2.0.3",
     "ramda": "^0.26.1",
     "ramda-adjunct": "^2.17.0",
+    "tiny-async-pool": "^1.0.4",
     "traverse": "^0.6.6",
     "uuid": "^3.3.2",
     "yup": "^0.27.0"

--- a/src/validatePluginOptions.js
+++ b/src/validatePluginOptions.js
@@ -5,6 +5,7 @@ import {
   mixed as yupMixed,
   object as yupObject,
   string as yupString,
+  number as yupNumber,
 } from 'yup'
 
 const baseValidations = {
@@ -41,6 +42,7 @@ const baseValidations = {
   repositoryName: yupString()
     .nullable()
     .required(),
+  concurrentFileRequests: yupNumber().default(20),
 }
 
 export const validatePluginOptions = (pluginOptions, requireSchemas = true) => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -6281,6 +6281,14 @@ timed-out@^4.0.0:
   resolved "https://registry.yarnpkg.com/timed-out/-/timed-out-4.0.1.tgz#f32eacac5a175bea25d7fab565ab3ed8741ef56f"
   integrity sha1-8y6srFoXW+ol1/q1Zas+2HQe9W8=
 
+tiny-async-pool@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/tiny-async-pool/-/tiny-async-pool-1.0.4.tgz#bbac28a39a754576d8d0615d4e2ad35c87da6169"
+  integrity sha512-4gdLvReS3WwmPCxZjj38Go673xhEXlK77fVFA2x+dE2Bf9QzDkVQb3rdO1iJt337ybhir42m4zM2GHJjiuFwoA==
+  dependencies:
+    semver "^5.5.0"
+    yaassertion "^1.0.0"
+
 tmp@^0.0.33:
   version "0.0.33"
   resolved "https://registry.yarnpkg.com/tmp/-/tmp-0.0.33.tgz#6d34335889768d21b2bcda0aa277ced3b1bfadf9"
@@ -6704,6 +6712,11 @@ xtend@~4.0.1:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/y18n/-/y18n-4.0.0.tgz#95ef94f85ecc81d007c264e190a120f0a3c8566b"
   integrity sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==
+
+yaassertion@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/yaassertion/-/yaassertion-1.0.0.tgz#630c5c44c660d064006f1f15d79bd256d373fc9e"
+  integrity sha512-fepEqRG+/2ZkJBf2ioA4LTOZUWrBN3F2EuKms3zE47M0zqph5aWs6SGiyz9wyzPkowhtiKapHV52IsRBfYCDwA==
 
 yallist@^3.0.0, yallist@^3.0.2:
   version "3.0.3"


### PR DESCRIPTION
Hey,

I struggled a while on that one: if you have a lot of images on your Prismic repo (~ > 100 images), the project become impossible to start/build at all and you're stuck in a loop hole.
The reason for this is quite complex but it's not specific to `gatsby-source-prismic` and it's been hapening on other source plugins as well like Drupal and Wordpress (see https://github.com/gatsbyjs/gatsby/issues/12848 for details).
I basically implemented the solution provided by @bakeruk using the `tiny-async-pool` library.

With this solution it's been working 100% of the time on large repositories of more than 200 images on a fairly unstable connection as well.

I open it in WIP to know what you think and because I didn't finish testing the `concurrentFileRequest` option (but should be working just fine).

Hope this help :)