### PR TITLE
WIP: Added try catches to normalizer functions for easier debugging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 node_modules
 dist
 .DS_Store
+.idea/

--- a/src/node/normalizers.js
+++ b/src/node/normalizers.js
@@ -10,21 +10,26 @@ export const normalizeStructuredTextField = async (
   _depth,
   context,
 ) => {
-  const { doc, pluginOptions } = context
-  const { linkResolver, htmlSerializer } = pluginOptions
+  try {
+    const { doc, pluginOptions } = context
+    const { linkResolver, htmlSerializer } = pluginOptions
 
-  const linkResolverForField = linkResolver({ key: id, value, node: doc })
-  const htmlSerializerForField = htmlSerializer({ key: id, value, node: doc })
+    const linkResolverForField = linkResolver({ key: id, value, node: doc })
+    const htmlSerializerForField = htmlSerializer({ key: id, value, node: doc })
 
-  return {
-    html: PrismicDOM.RichText.asHtml(
-      value,
-      linkResolverForField,
-      htmlSerializerForField,
-    ),
-    text: PrismicDOM.RichText.asText(value),
-    raw: value,
+    return {
+      html: PrismicDOM.RichText.asHtml(
+        value,
+        linkResolverForField,
+        htmlSerializerForField,
+      ),
+      text: PrismicDOM.RichText.asText(value),
+      raw: value,
+    }
+  } catch (error) {
+    // Ignore
   }
+
 }
 
 // Normalizes a PrismicLinkType field by providing a resolved URL using
@@ -34,21 +39,26 @@ export const normalizeStructuredTextField = async (
 // NOTE: The document field is set to a node ID but this will be resolved to
 // the node in the GraphQL resolver.
 export const normalizeLinkField = async (id, value, _depth, context) => {
-  const { doc, createNodeId, pluginOptions } = context
-  const { linkResolver } = pluginOptions
+  try {
+    const { doc, createNodeId, pluginOptions } = context
+    const { linkResolver } = pluginOptions
 
-  const linkResolverForField = linkResolver({ key: id, value, node: doc })
+    const linkResolverForField = linkResolver({ key: id, value, node: doc })
 
-  let documentId = null
-  if (value.link_type === 'Document')
-    documentId = createNodeId(`${value.type} ${value.id}`)
+    let documentId = null
+    if (value.link_type === 'Document')
+      documentId = createNodeId(`${value.type} ${value.id}`)
 
-  return {
-    ...value,
-    url: PrismicDOM.Link.url(value, linkResolverForField),
-    document: documentId,
-    raw: value,
+    return {
+      ...value,
+      url: PrismicDOM.Link.url(value, linkResolverForField),
+      document: documentId,
+      raw: value,
+    }
+  } catch (error) {
+    // Ignore
   }
+
 }
 
 // Normalizes a PrismicImageType field by creating a File node using


### PR DESCRIPTION
Some background: we have an extremely complicated schema for our project (it probably shouldn't be using prismic but here we are). Sometimes we get these strange errors and its extremely difficult to debug them without these functions having a catch to break on. 

@angeloashmore 
The reason for WIP is because I think we should have some kind of uniform error handler to output something useful regarding the schema like the contents of `_depth` in the error. Tell me what you think and if you want me to cook something up.

