### PR TITLE
Fix previews mysteriously failing to redirect

### DIFF
--- a/src/browser/normalizers.js
+++ b/src/browser/normalizers.js
@@ -57,13 +57,13 @@ export const normalizeLinkField = async (id, value, _depth, context) => {
   const linkedDocId = createNodeId(`${value.type} ${value.id}`)
 
   // Fetches, normalizes, and caches linked document if not present in cache.
-  if (value.link_type === 'Document' && value.id)
+  if (value.link_type === 'Document' && value.id && value.type !== 'broken_type')
     await fetchAndCreateDocumentNodes(value, context)
 
   const proxyHandler = {
     get: (obj, prop) => {
       if (prop === 'document') {
-        if (value.link_type === 'Document') return getNodeById(linkedDocId)
+        if (value.link_type === 'Document' && value.type !== 'broken_type') return getNodeById(linkedDocId)
 
         return null
       }
@@ -71,7 +71,6 @@ export const normalizeLinkField = async (id, value, _depth, context) => {
       return obj[prop]
     },
   }
-
   return new Proxy(
     {
       ...value,


### PR DESCRIPTION
It was tough to track down but we have like 70 or so pages right now and randomly our previews stopped working. I finally figured out that when docs are deleted in Prismic its up to the content author to clean up any links associated to that doc. Prismic just puts the `type: 'broken_type'` on the document. Currently the `normlizeLinkField` method returns a null document if anything is wrong, my solution keeps with that functionality. 

#137 