### PR TITLE
feat: add alternate language support

### DIFF
--- a/src/__tests__/browser/normalizers.js
+++ b/src/__tests__/browser/normalizers.js
@@ -20,6 +20,7 @@ const linkResolver = jest.fn().mockReturnValue(() => linkResolverReturnValue)
 
 const context = {
   doc: { id: 'id' },
+  typePaths: [],
   createNodeId,
   hasNodeById: () => {},
   gatsbyContext: { actions: {} },

--- a/src/__tests__/common/documentToNodes.js
+++ b/src/__tests__/common/documentToNodes.js
@@ -40,6 +40,7 @@ const linkResolver = jest.fn().mockReturnValue(() => linkResolverReturnValue)
 
 const baseContext = {
   pluginOptions: { linkResolver },
+  typePaths: [],
   createNode,
   createNodeId,
   createContentDigest,

--- a/src/__tests__/node/generateTypeDefsForCustomType.js
+++ b/src/__tests__/node/generateTypeDefsForCustomType.js
@@ -210,32 +210,7 @@ describe('generateTypeDefsForCustomType', () => {
           context,
         )
 
-        expect(typeDefs[0].config.fields.key).toMatchObject({
-          type: 'PrismicLinkType',
-        })
-      })
-
-      test('PrismicLinkType resolver gets document node by ID', () => {
-        const { typeDefs } = generateTypeDefsForCustomType(
-          customTypeId,
-          { Main: { key: { type: 'Link' } } },
-          context,
-        )
-
-        const resolver = typeDefs[0].config.fields.key.resolve
-        const getNodeById = jest.fn()
-
-        resolver(
-          { link: { id: 'id', type: 'custom_type' } },
-          undefined,
-          { nodeModel: { getNodeById } },
-          { path: { key: 'link' } },
-        )
-
-        expect(getNodeById).toHaveBeenCalledWith({
-          id: 'result of createNodeId',
-          type: 'PrismicCustomType',
-        })
+        expect(typeDefs[0].config.fields.key).toBe('PrismicLinkType')
       })
     })
 
@@ -477,6 +452,10 @@ describe('generateTypeDefsForCustomType', () => {
 
       expect(typePaths).toEqual([
         { path: ['custom_type', 'uid'], type: 'String' },
+        {
+          path: ['custom_type', 'alternate_languages'],
+          type: 'AlternateLanguages',
+        },
         { path: ['custom_type', 'data', 'text'], type: 'String' },
         {
           path: ['custom_type', 'data', 'body', 'slice', 'primary', 'key'],

--- a/src/common/standardTypes.graphql
+++ b/src/common/standardTypes.graphql
@@ -133,7 +133,7 @@ type PrismicLinkType {
   link_type: PrismicLinkTypes!
   "If a Document link, `true` if linked document does not exist, `false` otherwise."
   isBroken: Boolean
-  "The link URL using `prismic-dom` the link resolver."
+  "The document's URL derived via the link resolver."
   url: String
   "The link's target."
   target: String
@@ -152,7 +152,7 @@ type PrismicLinkType {
   "If a Document link, the linked document's UID."
   uid: String
   "If a Document link, the linked document."
-  document: PrismicAllDocumentTypes
+  document: PrismicAllDocumentTypes @link
   "The field's value without transformations exactly as it comes from the Prismic API."
   raw: JSON
 }
@@ -210,6 +210,8 @@ interface PrismicDocument {
   ): Date
   "The document's list of tags."
   tags: [String!]!
+  "Alternate languages for the document."
+  alternate_languages: [PrismicLinkType!]!
   "The document's Prismic API ID type."
   type: String!
   "The document's Prismic ID."


### PR DESCRIPTION
Adds `alternate_languages` as a field on all Prismic documents. `alternate_languages` is of type `[PrismicLinkType!]!` which allows querying the document directly.

The following example demonstrates:

```graphql
query {
  allPrismicPage {
    nodes {
      uid
      alternate_languages {
        ... on PrismicPage {
          uid
          data {
            title {
              text
            }
          }
        }
      } 
    }
  }
}
```