### PR TITLE
Add `releaseID` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -652,6 +652,11 @@ curl https://my-repository-name.prismic.io/api/v2
 In the `refs` array you want to look at the `id` field of the `ref` object where
 the label of your release is.
 
+Note that a release build is totally compatible with the preview system
+explained in the [preview guide](./docs/previews-guide.md). Using a `releaseID`
+is a way to view at once another version of your website, but under the hood
+it works the same way as the default build. So you can preview a draft of one
+document of your release just like you would do with the master version.
 
 ## Limitations
 

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ repositories.
   - [Query direct API data as a fallback](#Query-direct-API-data-as-a-fallback)
   - [Image processing](#Image-processing)
 - [Previews](#Previews)
+- [Releases](#Releases)
 - [Limitations](#Limitations)
   - [GraphQL-valid field names](#GraphQL-valid-field-names)
 - [Site's `gatsby-node.js` example](#Sites-gatsby-nodejs-example)
@@ -633,6 +634,24 @@ To learn more about local image processing, check the documentation of
 
 For an in-depth guide on using previews, please refer to
 [this guide](./docs/previews-guide.md).
+
+## Releases
+
+You can provide a `releaseID` option to build a release version of your website.
+See [How to use](#How-to-use) section.
+To learn more about prismic releases, see:
+https://user-guides.prismic.io/en/collections/22653-releases-scheduling#the-basics-of-a-release
+
+You can get a releaseID by using the prismic API:
+
+```
+curl https://my-repository-name.prismic.io/api/v2
+{"refs":[{"id":"master","ref":"XoS0aRAAAB8AmarD","label":"Master","isMasterRef":true},{"id":"Xny9FRAAAB4AdbNo","ref":"Xr024BEAAFNM2PNM~XoS0aRAAAB8AmarD","label":"My release"}], ... }
+```
+
+In the `refs` array you want to look at the `id` field of the `ref` object where
+the label of your release is.
+
 
 ## Limitations
 

--- a/README.md
+++ b/README.md
@@ -69,6 +69,15 @@ plugins: [
       // The token will be listed under "Permanent access tokens".
       accessToken: 'example-wou7evoh0eexuf6chooz2jai2qui9pae4tieph1sei4deiboj',
 
+      // Optional. If you provide a releaseID, the plugin will fetch prismic
+      // data for a specific release. A prismic release is a way to
+      // gather a collection of changes for a future version of your website.
+      // Note that if you add changes to a release, you'll need to build again
+      // your website to see them.
+      // Learn more about prismic releases here:
+      // https://user-guides.prismic.io/en/collections/22653-releases-scheduling#the-basics-of-a-release
+      releaseID: 'XXXXXXXXXXXXXXXX',
+
       // Set a link resolver function used to process links in your content.
       // Fields with rich text formatting or links to internal content use this
       // function to generate the correct link URL.

--- a/src/api.ts
+++ b/src/api.ts
@@ -47,12 +47,20 @@ export const fetchAllDocuments = async (
   pluginOptions: PluginOptions,
   gatsbyContext: SourceNodesArgs,
 ) => {
-  const { repositoryName, accessToken, fetchLinks, lang } = pluginOptions
+  const { repositoryName, releaseID, accessToken, fetchLinks, lang } = pluginOptions
   const { reporter } = gatsbyContext
 
   const client = await createClient(repositoryName, accessToken)
 
   const queryOptions: QueryOptions = {}
+  if (releaseID) {
+    const ref = client.refs.find(r => r.id === releaseID)
+    if (ref) {
+      queryOptions.ref = ref.ref
+    } else {
+      console.warn(`The release ${releaseID} was not found`)
+    }
+  }
   if (fetchLinks) queryOptions.fetchLinks = fetchLinks
   if (lang) queryOptions.lang = lang
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -386,7 +386,7 @@ export interface PluginOptions extends GatsbyPluginOptions {
   linkResolver?: PluginLinkResolver
   htmlSerializer?: PluginHTMLSerializer
   fetchLinks?: string[]
-  schemas: Schemas
+  schemas?: Schemas
   lang?: string
   shouldDownloadImage?: ShouldDownloadImage
   shouldNormalizeImage?: ShouldDownloadImage

--- a/src/types.ts
+++ b/src/types.ts
@@ -386,7 +386,7 @@ export interface PluginOptions extends GatsbyPluginOptions {
   linkResolver?: PluginLinkResolver
   htmlSerializer?: PluginHTMLSerializer
   fetchLinks?: string[]
-  schemas?: Schemas
+  schemas: Schemas
   lang?: string
   shouldDownloadImage?: ShouldDownloadImage
   shouldNormalizeImage?: ShouldDownloadImage

--- a/src/types.ts
+++ b/src/types.ts
@@ -381,6 +381,7 @@ export type BrowserPluginOptions = GatsbyPluginOptions &
 
 export interface PluginOptions extends GatsbyPluginOptions {
   repositoryName: string
+  releaseID?: string
   accessToken?: string
   linkResolver?: PluginLinkResolver
   htmlSerializer?: PluginHTMLSerializer

--- a/src/usePrismicPreview.ts
+++ b/src/usePrismicPreview.ts
@@ -27,6 +27,7 @@ type Options = Pick<
   | 'fetchLinks'
   | 'lang'
   | 'typePathsFilenamePrefix'
+  | 'schemas'
 > & {
   pathResolver?: PluginOptions['linkResolver']
   schemasDigest?: string

--- a/src/validateOptions.ts
+++ b/src/validateOptions.ts
@@ -5,6 +5,7 @@ import { PluginOptions, BrowserPluginOptions } from './types'
 const baseSchema = {
   repositoryName: 'string',
   accessToken: 'string?',
+  releaseID: 'string?',
   linkResolver: 'function?',
   htmlSerializer: 'function?',
   fetchLinks: struct.optional(['string']),

--- a/test/__snapshots__/gatsby-node.test.ts.snap
+++ b/test/__snapshots__/gatsby-node.test.ts.snap
@@ -92,7 +92,7 @@ exports[`sourceNodes creates nodes 1`] = `
             "raw": Object {
               "link_type": "Document",
             },
-            "url": undefined,
+            "url": "",
           },
           "title": Object {
             "html": "<h1>Home</h1>",

--- a/test/__snapshots__/usePrismicPreview.test.ts.snap
+++ b/test/__snapshots__/usePrismicPreview.test.ts.snap
@@ -124,7 +124,7 @@ Object {
         "raw": Object {
           "link_type": "Document",
         },
-        "url": undefined,
+        "url": "",
       },
       "title": Object {
         "html": "<h1>Home</h1>",


### PR DESCRIPTION
This brings a new feature: to be able to build statically your website using a prismic release.

From prismic doc:
> A release allows your team to gather a collection of changes for a future version of your whole repository. The release can then publish all the changes to all the collected documents all at the same time.

I've added a README section to hint on how to use release. The only way to get a `releaseID` currently is by using the REST API, as explained in the README.
We plan to add a more convenient way to get the release ID, by adding it in the prismic API browser, which is accessible from the editor. This way it would be simple to copy/paste it.