### PR TITLE
v3 migration guide: add section about `IntegrationFields`

### DIFF
--- a/docs/migrating-from-v2-to-v3.md
+++ b/docs/migrating-from-v2-to-v3.md
@@ -348,13 +348,17 @@ In v3, integration fields return a plain JSON and don't have subselections.
 There's no need to parse the JSON though.
 
 ```diff
-- event_shopify_product {
--   id
--   variants {
--     id
--   }
-+ event_shopify_product
-}
+  const query = graphql`
+    prismicPage {
++    event_shopify_product
+-    event_shopify_product {
+-      id
+-      variants {
+-        id
+-      }
+-    }
+    }
+  `
 ```
 
 ## Setting up previews

--- a/docs/migrating-from-v2-to-v3.md
+++ b/docs/migrating-from-v2-to-v3.md
@@ -13,6 +13,7 @@
   - [Namespacing image thumbnails](#namespacing-image-thumbnails)
   - [Using `raw` fields](#using-raw-fields)
   - [Replace `dataString` with `dataRaw`](#replace-datastring-with-dataraw)
+  - [Update `IntegrationFields`](#update-integrationfields)
 - [Setting up previews](#setting-up-previews)
 - [Things to know](#things-to-know)
   - [Type paths file in `/public`](#type-paths-file-in-public)
@@ -350,13 +351,13 @@ There's no need to parse the JSON though.
 ```diff
   const query = graphql`
     prismicPage {
-+    event_shopify_product
 -    event_shopify_product {
 -      id
 -      variants {
 -        id
 -      }
 -    }
++    event_shopify_product
     }
   `
 ```

--- a/docs/migrating-from-v2-to-v3.md
+++ b/docs/migrating-from-v2-to-v3.md
@@ -340,6 +340,23 @@ escape hatch if the untouched data is needed.
   `
 ```
 
+### Update `IntegrationFields`
+
+In v2, integration fields properties were available through the GraphQL API.
+
+In v3, integration fields return a plain JSON and don't have subselections.
+There's no need to parse the JSON though.
+
+```diff
+- event_shopify_product {
+-   id
+-   variants {
+-     id
+-   }
++ event_shopify_product
+}
+```
+
 ## Setting up previews
 
 See the [Previews guide](./previews-guide.md) to learn how to setup previews, a


### PR DESCRIPTION
Related to https://github.com/angeloashmore/gatsby-source-prismic/issues/113

>`v3.0.0` falls back to JSON type for unknown fields, including integration fields. You will automatically get the full object without specifying subfields. This is not ideal, but it is currently the best way to support integration fields.