### PR TITLE
Strip imgix params to download full quality image

### DIFF
--- a/src/environment.node.ts
+++ b/src/environment.node.ts
@@ -57,7 +57,7 @@ const normalizeImageField: ImageFieldNormalizer = async (
   } else {
     try {
       const fileNode = await createRemoteFileNode({
-        url: field.url,
+        url: field.url.split('?').shift() || field.url,
         store,
         cache,
         createNode,


### PR DESCRIPTION
Hi,
Thanks a lot for the great work here.

Prismic automatically appends "auto=compress,format" to image path, meaning that the downloaded image has not the best possible quality.

Sharp then recompress the image and the quality is not optimal.

Thanks