### PR TITLE
feat: add _previewable field to mark previewable data

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -2,4 +2,5 @@ module.exports = {
   preset: 'ts-jest',
   testEnvironment: 'jsdom',
   testURL: 'https://example.com/',
+  setupFilesAfterEnv: ['./jest.setup.js'],
 }

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -1,0 +1,1 @@
+require('@testing-library/jest-dom')

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gatsby-source-prismic",
-  "version": "3.1.4-previews-fix.0",
+  "version": "3.1.4-previews-fix.1",
   "description": "Gatsby source plugin for building websites using prismic.io as a data source",
   "license": "MIT",
   "main": "dist/gatsby-source-prismic.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gatsby-source-prismic",
-  "version": "3.1.4",
+  "version": "3.1.4-previews-fix.0",
   "description": "Gatsby source plugin for building websites using prismic.io as a data source",
   "license": "MIT",
   "main": "dist/gatsby-source-prismic.js",

--- a/package.json
+++ b/package.json
@@ -55,6 +55,8 @@
     "@babel/plugin-proposal-optional-chaining": "^7.10.1",
     "@commitlint/cli": "^8.3.5",
     "@commitlint/config-conventional": "^8.3.4",
+    "@testing-library/jest-dom": "^5.11.0",
+    "@testing-library/react": "^10.4.4",
     "@testing-library/react-hooks": "^3.2.1",
     "@types/jest": "^25.2.3",
     "@types/lodash.isplainobject": "^4.0.6",

--- a/src/documentsToNodes.ts
+++ b/src/documentsToNodes.ts
@@ -235,6 +235,7 @@ export const documentToNodes = async (
       type: buildSchemaTypeName(doc.type),
       contentDigest: createContentDigest(doc),
     },
+    _previewable: doc.id,
   }
 
   createNode(node)

--- a/src/gatsby-browser.ts
+++ b/src/gatsby-browser.ts
@@ -31,7 +31,7 @@ export const onClientEntry: GatsbyBrowser['onClientEntry'] = (
     // The legacy Prismic Toolbar script requires setting the endpoint globally
     // to window.
     window.prismic = {
-      endpoint: `https://${pluginOptions.repositoryName}.prismic.io/api/v2`,
+      endpoint: `https://${pluginOptions.repositoryName}.cdn.prismic.io/api/v2`,
     }
 
   window[BROWSER_STORE_KEY] = Object.assign({}, window[BROWSER_STORE_KEY], {

--- a/src/gatsby-browser.ts
+++ b/src/gatsby-browser.ts
@@ -27,22 +27,14 @@ export const onClientEntry: GatsbyBrowser['onClientEntry'] = (
   _gatsbyContext,
   pluginOptions: BrowserPluginOptions,
 ) => {
-  const params = new URLSearchParams(window.location.search)
-  const isPreviewSession = params.has('token') && params.has('documentId')
-
-  if (!isPreviewSession) return
-
-  if (pluginOptions.prismicToolbar === 'legacy') {
+  if (pluginOptions.prismicToolbar === 'legacy')
     // The legacy Prismic Toolbar script requires setting the endpoint globally
     // to window.
     window.prismic = {
       endpoint: `https://${pluginOptions.repositoryName}.prismic.io/api/v2`,
     }
-  }
 
-  window[BROWSER_STORE_KEY] = window[BROWSER_STORE_KEY] || {}
-
-  Object.assign(window[BROWSER_STORE_KEY], {
+  window[BROWSER_STORE_KEY] = Object.assign({}, window[BROWSER_STORE_KEY], {
     [pluginOptions.repositoryName]: {
       pluginOptions: omit(pluginOptions, ['schemas', 'plugins']),
       schemasDigest: md5(JSON.stringify(pluginOptions.schemas)),

--- a/src/gatsby-node.ts
+++ b/src/gatsby-node.ts
@@ -13,7 +13,7 @@ import { msg } from './utils'
 import { GatsbyNode, SourceNodesArgs } from 'gatsby'
 import { PluginOptions } from './types'
 
-export const sourceNodes: GatsbyNode['sourceNodes'] = async (
+export const sourceNodes: NonNullable<GatsbyNode['sourceNodes']> = async (
   gatsbyContext: SourceNodesArgs,
   pluginOptions: PluginOptions,
 ) => {
@@ -105,9 +105,9 @@ export const sourceNodes: GatsbyNode['sourceNodes'] = async (
   writeTypePathsActivity.end()
 }
 
-export const onPreExtractQueries: GatsbyNode['onPreExtractQueries'] = (
-  gatsbyContext,
-) => {
+export const onPreExtractQueries: NonNullable<
+  GatsbyNode['onPreExtractQueries']
+> = (gatsbyContext) => {
   const { store } = gatsbyContext
   const { program } = store.getState()
 

--- a/src/gatsby-ssr.ts
+++ b/src/gatsby-ssr.ts
@@ -3,7 +3,7 @@ import { GatsbySSR, RenderBodyArgs } from 'gatsby'
 
 import { PluginOptions } from './types'
 
-export const onRenderBody: GatsbySSR['onRenderBody'] = async (
+export const onRenderBody: NonNullable<GatsbySSR['onRenderBody']> = async (
   gatsbyContext: RenderBodyArgs,
   pluginOptions: PluginOptions,
 ) => {

--- a/src/gatsby-ssr.ts
+++ b/src/gatsby-ssr.ts
@@ -7,7 +7,7 @@ export const onRenderBody: GatsbySSR['onRenderBody'] = async (
   gatsbyContext: RenderBodyArgs,
   pluginOptions: PluginOptions,
 ) => {
-  const { setHeadComponents } = gatsbyContext
+  const { setPostBodyComponents } = gatsbyContext
 
   if (!pluginOptions.prismicToolbar) return
 
@@ -30,9 +30,8 @@ export const onRenderBody: GatsbySSR['onRenderBody'] = async (
 
   const toolbarScript = React.createElement('script', {
     src: toolbarScriptUrl,
-    async: true,
     defer: true,
   })
 
-  setHeadComponents([toolbarScript])
+  setPostBodyComponents([toolbarScript])
 }

--- a/src/gqlTypes.ts
+++ b/src/gqlTypes.ts
@@ -301,5 +301,7 @@ export const types = gql`
     type: String!
     "The document's Prismic ID."
     prismicId: ID!
+    "Marks the document as previewable using Prismic's preview system. Include this field if updates to the document should be previewable by content editors before publishing. **Note: the value of this field is not stable and should not be used directly**."
+    _previewable: ID!
   }
 `

--- a/src/mergePrismicPreviewData.ts
+++ b/src/mergePrismicPreviewData.ts
@@ -1,20 +1,21 @@
+import { Node } from 'gatsby'
 import isPlainObject from 'lodash.isplainobject'
 
-import { Node } from 'gatsby'
+import { NodeTree } from './types'
 
-interface NodeTree {
-  [key: string]: Node
-}
-
-interface MergePrismicPreviewDataArgs {
-  staticData?: { [key: string]: any }
-  previewData?: NodeTree
-}
+// Root node field used to compare static data with preview data. If values are
+// equal, the preview node can be treated as an updated version of the static
+// node.
+const PREVIEWABLE_NODE_ID_FIELD = 'prismicId'
 
 const traverseAndReplace = (node: any, replacementNode: Node): any => {
   if (isPlainObject(node)) {
-    // If the node shares the same Prismic ID, replace it.
-    if (node.prismicId === replacementNode.prismicId) return replacementNode
+    // If the nodes share an ID, replace it.
+    if (
+      node[PREVIEWABLE_NODE_ID_FIELD] ===
+      replacementNode[PREVIEWABLE_NODE_ID_FIELD]
+    )
+      return replacementNode
 
     // We did not find the Node to replace. Iterate all properties and continue
     // to find the Node.
@@ -35,18 +36,57 @@ const traverseAndReplace = (node: any, replacementNode: Node): any => {
   return node
 }
 
-export const mergePrismicPreviewData = (
-  args: MergePrismicPreviewDataArgs,
-): NodeTree | undefined => {
-  const { staticData, previewData } = args
+export enum MergePrismicPreviewDataStrategy {
+  /** Traverse static data nodes and replace with preview data if IDs match. */
+  TraverseAndReplace = 'traverseAndReplace',
+  /** Replace or insert preview data at the root level */
+  RootReplaceOrInsert = 'rootReplaceOrInsert',
+}
 
+interface MergePrismicPreviewDataArgs {
+  staticData?: NodeTree
+  previewData?: NodeTree
+  strategy?: MergePrismicPreviewDataStrategy
+}
+
+/**
+ * Merges preview data with static data. Different merge strategies can be used
+ * for different environments.
+ */
+export const mergePrismicPreviewData = ({
+  staticData,
+  previewData,
+  strategy = MergePrismicPreviewDataStrategy.TraverseAndReplace,
+}: MergePrismicPreviewDataArgs): NodeTree | undefined => {
   if (!staticData && !previewData) return
   if (!staticData) return previewData
   if (!previewData) return staticData
 
-  const previewDataRootNodeKey = Object.keys(previewData)[0]
-  if (staticData.hasOwnProperty(previewDataRootNodeKey))
-    return { ...staticData, ...previewData }
+  switch (strategy) {
+    // Unpublished previews must return data at the root to ensure it is always
+    // available. If staticData and previewData share root-level keys, they are
+    // merged. Otherwise, data will be sibilings.
+    case MergePrismicPreviewDataStrategy.RootReplaceOrInsert:
+      return { ...staticData, ...previewData }
 
-  return traverseAndReplace(staticData, previewData[previewDataRootNodeKey])
+    // Traverse static data nodes and replace with preview data if IDs match.
+    case MergePrismicPreviewDataStrategy.TraverseAndReplace:
+    default: {
+      const previewDataRootNodeKey = Object.keys(previewData)[0]
+
+      // TODO: Remove in v4.0.0.
+      if (
+        staticData.hasOwnProperty(previewDataRootNodeKey) &&
+        !staticData[previewDataRootNodeKey][PREVIEWABLE_NODE_ID_FIELD]
+      ) {
+        // TODO: Add link to more details on @previewable.
+        console.warn(
+          'Warning: Merging preview data implicitly will be deprecated in gatsby-source-prismic v4.0.0.\n\nIf you are relying on this functionality, please update your GraphQL query to include the @previewable directive on nodes that should be previewable.\n\nSee <URL HERE> for more details.',
+        )
+        return { ...staticData, ...previewData }
+      }
+
+      return traverseAndReplace(staticData, previewData[previewDataRootNodeKey])
+    }
+  }
 }

--- a/src/mergePrismicPreviewData.ts
+++ b/src/mergePrismicPreviewData.ts
@@ -8,6 +8,10 @@ import { NodeTree } from './types'
 // node.
 const PREVIEWABLE_NODE_ID_FIELD = '_previewable'
 
+// TODO: Remove in v4.0.0
+// Same as PREVIEWABLE_NODE_ID_FIELD, but the legacy version that will be phased out in v4.0.0.
+const LEGACY_PREVIEWABLE_NODE_ID_FIELD = 'prismicId'
+
 const traverseAndReplace = (node: any, replacementNode: Node): any => {
   if (isPlainObject(node)) {
     // If the nodes share an ID, replace it.
@@ -16,6 +20,17 @@ const traverseAndReplace = (node: any, replacementNode: Node): any => {
       replacementNode[PREVIEWABLE_NODE_ID_FIELD]
     )
       return replacementNode
+
+    // TODO: Remove in v4.0.0
+    if (
+      node[LEGACY_PREVIEWABLE_NODE_ID_FIELD] ===
+      replacementNode[LEGACY_PREVIEWABLE_NODE_ID_FIELD]
+    ) {
+      console.warn(
+        'Warning: Merging nested preview data using the prismicId field will be deprecated in gatsby-source-prismic v4.0.0.\n\nIf you are relying on this functionality, please update your GraphQL query to include the _previewable field on documents that should be previewable.',
+      )
+      return replacementNode
+    }
 
     // We did not find the Node to replace. Iterate all properties and continue
     // to find the Node.
@@ -76,7 +91,8 @@ export const mergePrismicPreviewData = ({
       // TODO: Remove in v4.0.0.
       if (
         staticData.hasOwnProperty(previewDataRootNodeKey) &&
-        !staticData[previewDataRootNodeKey][PREVIEWABLE_NODE_ID_FIELD]
+        !staticData[previewDataRootNodeKey][PREVIEWABLE_NODE_ID_FIELD] &&
+        !staticData[previewDataRootNodeKey][LEGACY_PREVIEWABLE_NODE_ID_FIELD]
       ) {
         // TODO: Add link to more details on _previewable.
         console.warn(

--- a/src/mergePrismicPreviewData.ts
+++ b/src/mergePrismicPreviewData.ts
@@ -6,7 +6,7 @@ import { NodeTree } from './types'
 // Root node field used to compare static data with preview data. If values are
 // equal, the preview node can be treated as an updated version of the static
 // node.
-const PREVIEWABLE_NODE_ID_FIELD = 'prismicId'
+const PREVIEWABLE_NODE_ID_FIELD = '_previewable'
 
 const traverseAndReplace = (node: any, replacementNode: Node): any => {
   if (isPlainObject(node)) {
@@ -36,17 +36,16 @@ const traverseAndReplace = (node: any, replacementNode: Node): any => {
   return node
 }
 
-export enum MergePrismicPreviewDataStrategy {
-  /** Traverse static data nodes and replace with preview data if IDs match. */
-  TraverseAndReplace = 'traverseAndReplace',
-  /** Replace or insert preview data at the root level */
-  RootReplaceOrInsert = 'rootReplaceOrInsert',
-}
-
-interface MergePrismicPreviewDataArgs {
+export interface MergePrismicPreviewDataArgs {
   staticData?: NodeTree
   previewData?: NodeTree
-  strategy?: MergePrismicPreviewDataStrategy
+  /**
+   * Determines the method with which the function merges preview data into static data.
+   *
+   * - `traverseAndReplace`: Traverse static data nodes and replace with preview data if IDs match.
+   * - `rootReplaceOrInsert`: Replace or insert preview data at the root level.
+   */
+  strategy?: 'traverseAndReplace' | 'rootReplaceOrInsert'
 }
 
 /**
@@ -56,7 +55,7 @@ interface MergePrismicPreviewDataArgs {
 export const mergePrismicPreviewData = ({
   staticData,
   previewData,
-  strategy = MergePrismicPreviewDataStrategy.TraverseAndReplace,
+  strategy = 'traverseAndReplace',
 }: MergePrismicPreviewDataArgs): NodeTree | undefined => {
   if (!staticData && !previewData) return
   if (!staticData) return previewData
@@ -66,11 +65,11 @@ export const mergePrismicPreviewData = ({
     // Unpublished previews must return data at the root to ensure it is always
     // available. If staticData and previewData share root-level keys, they are
     // merged. Otherwise, data will be sibilings.
-    case MergePrismicPreviewDataStrategy.RootReplaceOrInsert:
+    case 'rootReplaceOrInsert':
       return { ...staticData, ...previewData }
 
     // Traverse static data nodes and replace with preview data if IDs match.
-    case MergePrismicPreviewDataStrategy.TraverseAndReplace:
+    case 'traverseAndReplace':
     default: {
       const previewDataRootNodeKey = Object.keys(previewData)[0]
 
@@ -81,7 +80,7 @@ export const mergePrismicPreviewData = ({
       ) {
         // TODO: Add link to more details on @previewable.
         console.warn(
-          'Warning: Merging preview data implicitly will be deprecated in gatsby-source-prismic v4.0.0.\n\nIf you are relying on this functionality, please update your GraphQL query to include the @previewable directive on nodes that should be previewable.\n\nSee <URL HERE> for more details.',
+          'Warning: Merging preview data implicitly will be deprecated in gatsby-source-prismic v4.0.0.\n\nIf you are relying on this functionality, please update your GraphQL query to include the _previewable field on nodes that should be previewable.\n\nSee <URL HERE> for more details.',
         )
         return { ...staticData, ...previewData }
       }

--- a/src/mergePrismicPreviewData.ts
+++ b/src/mergePrismicPreviewData.ts
@@ -80,7 +80,7 @@ export const mergePrismicPreviewData = ({
       ) {
         // TODO: Add link to more details on @previewable.
         console.warn(
-          'Warning: Merging preview data implicitly will be deprecated in gatsby-source-prismic v4.0.0.\n\nIf you are relying on this functionality, please update your GraphQL query to include the _previewable field on nodes that should be previewable.\n\nSee <URL HERE> for more details.',
+          'Warning: Merging preview data implicitly will be deprecated in gatsby-source-prismic v4.0.0.\n\nIf you are relying on this functionality, please update your GraphQL query to include the _previewable field on documents that should be previewable.\n\nSee <URL HERE> for more details.',
         )
         return { ...staticData, ...previewData }
       }

--- a/src/mergePrismicPreviewData.ts
+++ b/src/mergePrismicPreviewData.ts
@@ -78,9 +78,9 @@ export const mergePrismicPreviewData = ({
         staticData.hasOwnProperty(previewDataRootNodeKey) &&
         !staticData[previewDataRootNodeKey][PREVIEWABLE_NODE_ID_FIELD]
       ) {
-        // TODO: Add link to more details on @previewable.
+        // TODO: Add link to more details on _previewable.
         console.warn(
-          'Warning: Merging preview data implicitly will be deprecated in gatsby-source-prismic v4.0.0.\n\nIf you are relying on this functionality, please update your GraphQL query to include the _previewable field on documents that should be previewable.\n\nSee <URL HERE> for more details.',
+          'Warning: Merging preview data implicitly will be deprecated in gatsby-source-prismic v4.0.0.\n\nIf you are relying on this functionality, please update your GraphQL query to include the _previewable field on documents that should be previewable.',
         )
         return { ...staticData, ...previewData }
       }

--- a/src/schemasToTypeDefs.ts
+++ b/src/schemasToTypeDefs.ts
@@ -349,6 +349,7 @@ const schemaToTypeDefs = (
     alternate_languages: alternateLanguagesFieldType as string,
     type: `${GraphQLType.String}!`,
     prismicId: `${GraphQLType.ID}!`,
+    _previewable: `${GraphQLType.ID}!`,
   }
   if (uidFieldType) schemaFieldTypes.uid = uidFieldType
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -11,6 +11,10 @@ import { ImgixUrlParams } from 'gatsby-plugin-imgix'
 
 export type NodeID = string
 
+export interface NodeTree {
+  [key: string]: Node
+}
+
 export interface DocumentNodeInput extends NodeInput {
   prismicId: PrismicDocument['id']
   data: { [key: string]: NormalizedField }

--- a/src/usePreviewStore.tsx
+++ b/src/usePreviewStore.tsx
@@ -1,6 +1,9 @@
 import * as React from 'react'
 import { NodeTree } from './types'
 
+const DEFAULT_INITIAL_PAGES = {}
+const DEFAULT_INITIAL_ENABLED = false
+
 export enum ActionType {
   AddPage,
   EnablePreviews,
@@ -19,10 +22,11 @@ interface State {
   enabled: boolean
 }
 
-const initialState: State = {
-  pages: {},
-  enabled: false,
-}
+const createInitialState = (initialState?: Partial<State>): State => ({
+  pages: DEFAULT_INITIAL_PAGES,
+  enabled: DEFAULT_INITIAL_ENABLED,
+  ...initialState,
+})
 
 const reducer = (state: State, action: Action): State => {
   switch (action.type) {
@@ -47,19 +51,29 @@ const reducer = (state: State, action: Action): State => {
   }
 }
 
-const PreviewStoreContext = React.createContext([initialState, () => {}] as [
-  State,
-  React.Dispatch<Action>,
-])
+const PreviewStoreContext = React.createContext([
+  createInitialState(),
+  () => {},
+] as [State, React.Dispatch<Action>])
 
 export type PreviewStoreProviderProps = {
   children?: React.ReactNode
+  initialPages?: State['pages']
+  initialEnabled?: State['enabled']
 }
 
 export const PreviewStoreProvider = ({
   children,
+  initialPages = DEFAULT_INITIAL_PAGES,
+  initialEnabled = DEFAULT_INITIAL_ENABLED,
 }: PreviewStoreProviderProps) => {
-  const reducerTuple = React.useReducer(reducer, initialState)
+  const reducerTuple = React.useReducer(
+    reducer,
+    createInitialState({
+      pages: initialPages,
+      enabled: initialEnabled,
+    }),
+  )
 
   return (
     <PreviewStoreContext.Provider value={reducerTuple}>

--- a/src/usePreviewStore.tsx
+++ b/src/usePreviewStore.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react'
+import { NodeTree } from './types'
 
 export enum ActionType {
   AddPage,
@@ -9,12 +10,12 @@ export enum ActionType {
 type Action =
   | {
       type: ActionType.AddPage
-      payload: { path: string; data: object }
+      payload: { path: string; data: NodeTree }
     }
   | { type: Exclude<ActionType, ActionType.AddPage> }
 
 interface State {
-  pages: Record<string, object>
+  pages: Record<string, NodeTree>
   enabled: boolean
 }
 

--- a/src/validateOptions.ts
+++ b/src/validateOptions.ts
@@ -62,6 +62,7 @@ const BrowserOptionsValidator = struct(
     ...baseSchema,
     pathResolver: 'function?',
     schemasDigest: 'string',
+    plugins: struct.union([struct.literal(undefined), struct.size([0, 0])]),
   },
   baseDefaults,
 )

--- a/src/withPreview.tsx
+++ b/src/withPreview.tsx
@@ -20,7 +20,7 @@ export const withPreview = <TProps extends PageProps>(
   const WithPreview = (props: TProps) => {
     const [state] = usePreviewStore()
 
-    const path = props.location.pathname
+    const path = props.path
     const staticData = props.data as NodeTree
     const previewData = state.pages[path]
 

--- a/src/withPreview.tsx
+++ b/src/withPreview.tsx
@@ -3,14 +3,14 @@ import { PageProps } from 'gatsby'
 
 import {
   mergePrismicPreviewData,
-  MergePrismicPreviewDataStrategy,
+  MergePrismicPreviewDataArgs,
 } from './mergePrismicPreviewData'
 import { usePreviewStore } from './usePreviewStore'
 import { getComponentDisplayName } from './utils'
 import { NodeTree } from './types'
 
 type WithPreviewArgs = {
-  mergeStrategy?: MergePrismicPreviewDataStrategy
+  mergeStrategy?: MergePrismicPreviewDataArgs['strategy']
 }
 
 export const withPreview = <TProps extends PageProps>(
@@ -20,7 +20,7 @@ export const withPreview = <TProps extends PageProps>(
   const WithPreview = (props: TProps) => {
     const [state] = usePreviewStore()
 
-    const path = props.path
+    const path = props.location.pathname
     const staticData = props.data as NodeTree
     const previewData = state.pages[path]
 

--- a/src/withPreview.tsx
+++ b/src/withPreview.tsx
@@ -1,18 +1,27 @@
 import * as React from 'react'
-import { PageProps, Node } from 'gatsby'
+import { PageProps } from 'gatsby'
 
-import { mergePrismicPreviewData } from './mergePrismicPreviewData'
+import {
+  mergePrismicPreviewData,
+  MergePrismicPreviewDataStrategy,
+} from './mergePrismicPreviewData'
 import { usePreviewStore } from './usePreviewStore'
 import { getComponentDisplayName } from './utils'
+import { NodeTree } from './types'
+
+type WithPreviewArgs = {
+  mergeStrategy?: MergePrismicPreviewDataStrategy
+}
 
 export const withPreview = <TProps extends PageProps>(
   WrappedComponent: React.ComponentType<TProps>,
+  options?: WithPreviewArgs,
 ): React.ComponentType<TProps> => {
   const WithPreview = (props: TProps) => {
     const [state] = usePreviewStore()
 
     const path = props.location.pathname
-    const staticData = props.data
+    const staticData = props.data as NodeTree
     const previewData = state.pages[path]
 
     const data = React.useMemo(
@@ -20,7 +29,8 @@ export const withPreview = <TProps extends PageProps>(
         state.enabled
           ? mergePrismicPreviewData({
               staticData,
-              previewData: previewData as { [key: string]: Node },
+              previewData,
+              strategy: options?.mergeStrategy,
             })
           : staticData,
       [state.enabled, staticData, previewData],

--- a/src/withUnpublishedPreview.tsx
+++ b/src/withUnpublishedPreview.tsx
@@ -4,6 +4,7 @@ import { PageProps } from 'gatsby'
 import { usePreviewStore } from './usePreviewStore'
 import { withPreview } from './withPreview'
 import { msg, getComponentDisplayName } from './utils'
+import { MergePrismicPreviewDataStrategy } from './mergePrismicPreviewData'
 
 type WithUnpublishedPreviewArgs = {
   templateMap: Record<string, React.ComponentType<any>>
@@ -15,23 +16,22 @@ export const withUnpublishedPreview = <TProps extends PageProps>(
 ): React.ComponentType<TProps> => {
   const WithUnpublishedPreview = (props: TProps) => {
     const [state] = usePreviewStore()
-    const isPreview = state.pages.hasOwnProperty(props.location.pathname)
+    const path = props.location.pathname
+    const isPreview = state.pages.hasOwnProperty(path)
 
     if (isPreview) {
-      const key = Object.keys(props.data)[0]
-      const TemplateComp =
-        options.templateMap[
-          (props.data as Record<string, { type?: string }>)[key]
-            .type as keyof typeof options.templateMap
-        ]
-
-      console.warn(
-        msg(
-          `An unpublished preview was detected, but a template component could not be found for a custom type of "${key}". Check that the templateMap option in withUnpublishedPreview includes a component for "${key}". withUnpublishedPreview will yield to the wrapped component to render.`,
-        ),
-      )
+      const previewData = state.pages[path]
+      const key = Object.keys(previewData)[0]
+      const type = previewData[key].type as string
+      const TemplateComp = options.templateMap[type]
 
       if (TemplateComp) return <TemplateComp {...props} />
+      else
+        console.warn(
+          msg(
+            `An unpublished preview was detected, but a template component could not be found for a custom type of "${type}". Check that the templateMap option in withUnpublishedPreview includes a component for "${type}". withUnpublishedPreview will yield to the wrapped component to render.`,
+          ),
+        )
     }
 
     return <WrappedComponent {...props} />
@@ -40,5 +40,9 @@ export const withUnpublishedPreview = <TProps extends PageProps>(
     WrappedComponent,
   )})`
 
-  return withPreview(WithUnpublishedPreview)
+  return withPreview(WithUnpublishedPreview, {
+    // In an unpublished preview, we have to assume the component accepts the
+    // preview data as a root-level field.
+    mergeStrategy: MergePrismicPreviewDataStrategy.RootReplaceOrInsert,
+  })
 }

--- a/src/withUnpublishedPreview.tsx
+++ b/src/withUnpublishedPreview.tsx
@@ -4,7 +4,6 @@ import { PageProps } from 'gatsby'
 import { usePreviewStore } from './usePreviewStore'
 import { withPreview } from './withPreview'
 import { msg, getComponentDisplayName } from './utils'
-import { MergePrismicPreviewDataStrategy } from './mergePrismicPreviewData'
 
 type WithUnpublishedPreviewArgs = {
   templateMap: Record<string, React.ComponentType<any>>
@@ -43,6 +42,6 @@ export const withUnpublishedPreview = <TProps extends PageProps>(
   return withPreview(WithUnpublishedPreview, {
     // In an unpublished preview, we have to assume the component accepts the
     // preview data as a root-level field.
-    mergeStrategy: MergePrismicPreviewDataStrategy.RootReplaceOrInsert,
+    mergeStrategy: 'rootReplaceOrInsert',
   })
 }

--- a/test/__fixtures__/pageData.ts
+++ b/test/__fixtures__/pageData.ts
@@ -7,6 +7,7 @@ export const MOCK_PAGE_PROPS = {
 }
 
 export const MOCK_NODE = {
+  _previewable: 'id',
   id: 'id',
   parent: '__SOURCE__',
   children: [],

--- a/test/__fixtures__/pageData.ts
+++ b/test/__fixtures__/pageData.ts
@@ -1,0 +1,42 @@
+export const STATIC_UID = 'static'
+export const PREVIEW_UID = 'preview'
+
+export const MOCK_PAGE_PROPS = {
+  path: '/',
+  location,
+}
+
+export const MOCK_NODE = {
+  id: 'id',
+  parent: '__SOURCE__',
+  children: [],
+  internal: {
+    type: 'MockNode',
+    contentDigest: 'contentDigest',
+    owner: 'owner',
+  },
+}
+
+export const STATIC_DATA = {
+  prismicPage: {
+    ...MOCK_NODE,
+    prismicId: 'prismicId',
+    uid: STATIC_UID,
+    type: 'page',
+  },
+  prismicOtherData: {
+    ...MOCK_NODE,
+    prismicId: 'otherPrismicId',
+    uid: 'otherUID',
+    type: 'otherData',
+  },
+}
+
+export const PREVIEW_DATA = {
+  prismicPage: {
+    ...MOCK_NODE,
+    prismicId: 'prismicId',
+    uid: PREVIEW_UID,
+    type: 'page',
+  },
+}

--- a/test/__snapshots__/gatsby-node.test.ts.snap
+++ b/test/__snapshots__/gatsby-node.test.ts.snap
@@ -77,6 +77,7 @@ exports[`sourceNodes creates nodes 1`] = `
     ],
     Array [
       Object {
+        "_previewable": "XDF-DhEAACAA5b4F",
         "alternate_languages": Array [],
         "data": Object {
           "body": Array [
@@ -351,6 +352,7 @@ exports[`sourceNodes creates types 1`] = `
               "infer": false,
             },
             "fields": Object {
+              "_previewable": "ID!",
               "alternate_languages": "[PrismicLinkType!]!",
               "data": "PrismicPageDataType",
               "dataRaw": "JSON!",
@@ -740,6 +742,8 @@ exports[`sourceNodes creates types 1`] = `
     type: String!
     \\"The document's Prismic ID.\\"
     prismicId: ID!
+    \\"Marks the document as previewable using Prismic's preview system. Include this field if updates to the document should be previewable by content editors before publishing. **Note: the value of this field is not stable and should not be used directly**.\\"
+    _previewable: ID!
   }
 ",
     ],

--- a/test/__snapshots__/usePrismicPreview.test.ts.snap
+++ b/test/__snapshots__/usePrismicPreview.test.ts.snap
@@ -3,6 +3,7 @@
 exports[`usePrismicPreview updates state while fetching preview 1`] = `
 Object {
   "prismicPage": Object {
+    "_previewable": "documentId",
     "alternate_languages": Array [],
     "data": Object {
       "body": Array [

--- a/test/gatsby-node.test.ts
+++ b/test/gatsby-node.test.ts
@@ -9,133 +9,6 @@ jest.mock('fs')
 
 const PROGRAM_DIRECTORY_PATH = '/__PROGRAM_DIRECTORY__/'
 
-const mockActions = {
-  deletePage: jest.fn(),
-  createPage: jest.fn(),
-  deleteNode: jest.fn(),
-  deleteNodes: jest.fn(),
-  createNode: jest.fn(),
-  touchNode: jest.fn(),
-  createNodeField: jest.fn(),
-  createParentChildLink: jest.fn(),
-  setWebpackConfig: jest.fn(),
-  replaceWebpackConfig: jest.fn(),
-  setBabelOptions: jest.fn(),
-  setBabelPlugin: jest.fn(),
-  setBabelPreset: jest.fn(),
-  createJob: jest.fn(),
-  createJobV2: jest.fn(),
-  setJob: jest.fn(),
-  endJob: jest.fn(),
-  setPluginStatus: jest.fn(),
-  createRedirect: jest.fn(),
-  addThirdPartySchema: jest.fn(),
-  createTypes: jest.fn(),
-  createFieldExtension: jest.fn(),
-}
-
-const mockGatsbyContext: ParentSpanPluginArgs = {
-  pathPrefix: 'pathPrefix',
-  boundActionCreators: mockActions,
-  actions: mockActions,
-  loadNodeContent: jest.fn(),
-  store: {
-    dispatch: jest.fn(),
-    subscribe: jest.fn(),
-    getState: jest
-      .fn()
-      .mockReturnValue({ program: { directory: PROGRAM_DIRECTORY_PATH } }),
-    replaceReducer: jest.fn(),
-  },
-  emitter: {
-    addListener: jest.fn(),
-    on: jest.fn(),
-    once: jest.fn(),
-    prependListener: jest.fn(),
-    prependOnceListener: jest.fn(),
-    removeListener: jest.fn(),
-    off: jest.fn(),
-    removeAllListeners: jest.fn(),
-    setMaxListeners: jest.fn(),
-    getMaxListeners: jest.fn(),
-    listeners: jest.fn(),
-    rawListeners: jest.fn(),
-    emit: jest.fn(),
-    eventNames: jest.fn(),
-    listenerCount: jest.fn(),
-  },
-  getNodes: jest.fn(),
-  getNode: jest.fn(),
-  getNodesByType: jest.fn(),
-  hasNodeChanged: jest.fn(),
-  reporter: {
-    stripIndent: jest.fn(),
-    format: jest.fn(),
-    setVerbose: jest.fn(),
-    setNoColor: jest.fn(),
-    panic: jest.fn().mockImplementation((msg: string | Error, err?: Error) => {
-      throw err ?? msg
-    }),
-    panicOnBuild: jest
-      .fn()
-      .mockImplementation((msg: string | Error, err?: Error) => {
-        throw err ?? msg
-      }),
-    error: jest.fn(),
-    uptime: jest.fn(),
-    success: jest.fn(),
-    verbose: jest.fn(),
-    info: jest.fn(),
-    warn: jest.fn(),
-    log: jest.fn(),
-    activityTimer: jest.fn().mockReturnValue({
-      start: jest.fn(),
-      end: jest.fn(),
-    }),
-    createProgress: jest.fn(),
-  },
-  getNodeAndSavePathDependency: jest.fn(),
-  cache: {
-    set: jest.fn(),
-    get: jest.fn(),
-  },
-  createNodeId: jest.fn().mockReturnValue('createNodeId'),
-  createContentDigest: jest.fn().mockReturnValue('createContentDigest'),
-  tracing: {
-    tracer: {},
-    parentSpan: {},
-    startSpan: jest.fn(),
-  },
-  parentSpan: {},
-  schema: {
-    buildObjectType: jest
-      .fn()
-      .mockImplementation((config) => ({ kind: 'OBJECT', config })),
-    buildUnionType: jest.fn().mockImplementation((config) => ({
-      kind: 'UNION',
-      config,
-    })),
-    buildInterfaceType: jest
-      .fn()
-      .mockImplementation((config) => ({ kind: 'INTERFACE', config })),
-    buildInputObjectType: jest
-      .fn()
-      .mockImplementation((config) => ({ kind: 'INPUT', config })),
-    buildEnumType: jest
-      .fn()
-      .mockImplementation((config) => ({ kind: 'ENUM', config })),
-    buildScalarType: jest
-      .fn()
-      .mockImplementation((config) => ({ kind: 'SCALAR', config })),
-  },
-}
-
-const mockSourceNodesGatsbyContext: SourceNodesArgs = {
-  ...mockGatsbyContext,
-  traceId: 'initial-sourceNodes',
-  waitForCascadingActions: false,
-}
-
 const pluginOptions = {
   repositoryName: 'repositoryName',
   plugins: [],
@@ -145,20 +18,53 @@ const pluginOptions = {
 describe('sourceNodes', () => {
   beforeEach(() => jest.clearAllMocks())
 
-  test('creates types', async () => {
-    await sourceNodes!(mockSourceNodesGatsbyContext, pluginOptions)
+  const mockGatsbyContext: SourceNodesArgs = {
+    // @ts-expect-error - partial implementation
+    actions: {
+      createTypes: jest.fn(),
+      createNode: jest.fn(),
+    },
+    // @ts-expect-error - partial implementation
+    store: {
+      getState: jest
+        .fn()
+        .mockReturnValue({ program: { directory: PROGRAM_DIRECTORY_PATH } }),
+    },
+    // @ts-expect-error - partial implementation
+    reporter: {
+      activityTimer: jest
+        .fn()
+        .mockReturnValue({ start: jest.fn(), end: jest.fn() }),
+      verbose: jest.fn(),
+    },
+    // @ts-expect-error - partial implementation
+    schema: {
+      buildObjectType: jest
+        .fn()
+        .mockImplementation((config) => ({ kind: 'OBJECT', config })),
+      buildUnionType: jest.fn().mockImplementation((config) => ({
+        kind: 'UNION',
+        config,
+      })),
+    },
+    createNodeId: jest.fn().mockReturnValue('createNodeId'),
+    createContentDigest: jest.fn().mockReturnValue('createContentDigest'),
+  }
 
-    expect(mockSourceNodesGatsbyContext.actions.createTypes).toMatchSnapshot()
+  test('creates types', async () => {
+    await sourceNodes(mockGatsbyContext, pluginOptions)
+
+    expect(mockGatsbyContext.actions.createTypes).toMatchSnapshot()
   })
 
   test('creates nodes', async () => {
-    await sourceNodes!(mockSourceNodesGatsbyContext, pluginOptions)
+    await sourceNodes(mockGatsbyContext, pluginOptions)
 
-    expect(mockSourceNodesGatsbyContext.actions.createNode).toMatchSnapshot()
+    expect(mockGatsbyContext.actions.createNode).toMatchSnapshot()
   })
 
   test('writes type paths to filesystem', async () => {
-    await sourceNodes!(mockSourceNodesGatsbyContext, pluginOptions)
+    await sourceNodes(mockGatsbyContext, pluginOptions)
 
     expect(
       (fs.writeFileSync as jest.Mock).mock.calls[0][0],
@@ -174,8 +80,17 @@ describe('sourceNodes', () => {
 })
 
 describe('onPreExtractQueries', () => {
+  const mockGatsbyContext: ParentSpanPluginArgs = {
+    // @ts-expect-error - partial implementation
+    store: {
+      getState: jest
+        .fn()
+        .mockReturnValue({ program: { directory: PROGRAM_DIRECTORY_PATH } }),
+    },
+  }
+
   test('copies fragments file to program cache', async () => {
-    onPreExtractQueries!(mockGatsbyContext, pluginOptions)
+    onPreExtractQueries(mockGatsbyContext, pluginOptions)
 
     const call = (fs.copyFileSync as jest.Mock).mock.calls[0]
 

--- a/test/gatsby-ssr.test.ts
+++ b/test/gatsby-ssr.test.ts
@@ -4,122 +4,6 @@ import { onRenderBody } from '../src/gatsby-ssr'
 
 import mockSchema from './__fixtures__/schema.json'
 
-const PROGRAM_DIRECTORY_PATH = '/__PROGRAM_DIRECTORY__/'
-
-const mockActions = {
-  deletePage: jest.fn(),
-  createPage: jest.fn(),
-  deleteNode: jest.fn(),
-  deleteNodes: jest.fn(),
-  createNode: jest.fn(),
-  touchNode: jest.fn(),
-  createNodeField: jest.fn(),
-  createParentChildLink: jest.fn(),
-  setWebpackConfig: jest.fn(),
-  replaceWebpackConfig: jest.fn(),
-  setBabelOptions: jest.fn(),
-  setBabelPlugin: jest.fn(),
-  setBabelPreset: jest.fn(),
-  createJob: jest.fn(),
-  createJobV2: jest.fn(),
-  setJob: jest.fn(),
-  endJob: jest.fn(),
-  setPluginStatus: jest.fn(),
-  createRedirect: jest.fn(),
-  addThirdPartySchema: jest.fn(),
-  createTypes: jest.fn(),
-  createFieldExtension: jest.fn(),
-}
-
-const mockGatsbyContext: RenderBodyArgs = {
-  boundActionCreators: mockActions,
-  actions: mockActions,
-  setHeadComponents: jest.fn(),
-  setHtmlAttributes: jest.fn(),
-  setBodyAttributes: jest.fn(),
-  setBodyProps: jest.fn(),
-  setPreBodyComponents: jest.fn(),
-  setPostBodyComponents: jest.fn(),
-  pathPrefix: 'pathPrefix',
-  pathname: 'pathname',
-  store: {
-    dispatch: jest.fn(),
-    subscribe: jest.fn(),
-    getState: jest
-      .fn()
-      .mockReturnValue({ program: { directory: PROGRAM_DIRECTORY_PATH } }),
-    replaceReducer: jest.fn(),
-  },
-  emitter: {
-    addListener: jest.fn(),
-    on: jest.fn(),
-    once: jest.fn(),
-    prependListener: jest.fn(),
-    prependOnceListener: jest.fn(),
-    removeListener: jest.fn(),
-    off: jest.fn(),
-    removeAllListeners: jest.fn(),
-    setMaxListeners: jest.fn(),
-    getMaxListeners: jest.fn(),
-    listeners: jest.fn(),
-    rawListeners: jest.fn(),
-    emit: jest.fn(),
-    eventNames: jest.fn(),
-    listenerCount: jest.fn(),
-  },
-  loadNodeContent: jest.fn(),
-  getNodes: jest.fn(),
-  getNode: jest.fn(),
-  getNodesByType: jest.fn(),
-  getNodeAndSavePathDependency: jest.fn(),
-  hasNodeChanged: jest.fn(),
-  reporter: {
-    stripIndent: jest.fn(),
-    format: jest.fn(),
-    setVerbose: jest.fn(),
-    setNoColor: jest.fn(),
-    panic: jest.fn().mockImplementation((msg: string | Error, err?: Error) => {
-      throw err ?? msg
-    }),
-    panicOnBuild: jest
-      .fn()
-      .mockImplementation((msg: string | Error, err?: Error) => {
-        throw err ?? msg
-      }),
-    error: jest.fn(),
-    uptime: jest.fn(),
-    success: jest.fn(),
-    verbose: jest.fn(),
-    info: jest.fn(),
-    warn: jest.fn(),
-    log: jest.fn(),
-    activityTimer: jest.fn().mockReturnValue({
-      start: jest.fn(),
-      end: jest.fn(),
-    }),
-    createProgress: jest.fn(),
-  },
-  cache: {
-    set: jest.fn(),
-    get: jest.fn(),
-  },
-  createNodeId: jest.fn().mockReturnValue('createNodeId'),
-  createContentDigest: jest.fn().mockReturnValue('createContentDigest'),
-  tracing: {
-    tracer: {},
-    parentSpan: {},
-    startSpan: jest.fn(),
-  },
-  schema: {
-    buildObjectType: jest.fn(),
-    buildUnionType: jest.fn(),
-    buildInterfaceType: jest.fn(),
-    buildInputObjectType: jest.fn(),
-    buildEnumType: jest.fn(),
-    buildScalarType: jest.fn(),
-  },
-}
-
 const pluginOptions = {
   repositoryName: 'repositoryName',
   plugins: [],
@@ -129,22 +13,27 @@ const pluginOptions = {
 describe('onRenderBody', () => {
   beforeEach(() => jest.clearAllMocks())
 
-  test('expect Prismic Toolbar script not to be included by default', async () => {
-    await onRenderBody!(mockGatsbyContext, pluginOptions)
+  // @ts-expect-error - partial implementation
+  const mockGatsbyContext: RenderBodyArgs = {
+    setPostBodyComponents: jest.fn(),
+  }
 
-    expect(mockGatsbyContext.setHeadComponents).not.toHaveBeenCalled()
+  test('expect Prismic Toolbar script not to be included by default', async () => {
+    await onRenderBody(mockGatsbyContext, pluginOptions)
+
+    expect(mockGatsbyContext.setPostBodyComponents).not.toHaveBeenCalled()
   })
 
   test('expect Prismic Toolbar script to be included if `prismicToolbar` is set to `true`', async () => {
-    await onRenderBody!(mockGatsbyContext, {
+    await onRenderBody(mockGatsbyContext, {
       ...pluginOptions,
       prismicToolbar: true,
     })
 
-    expect(mockGatsbyContext.setHeadComponents).toHaveBeenCalledTimes(1)
+    expect(mockGatsbyContext.setPostBodyComponents).toHaveBeenCalledTimes(1)
 
     expect(
-      (mockGatsbyContext.setHeadComponents as jest.Mock).mock.calls[0][0][0]
+      (mockGatsbyContext.setPostBodyComponents as jest.Mock).mock.calls[0][0][0]
         .props.src,
     ).toBe(
       `//static.cdn.prismic.io/prismic.js?repo=${pluginOptions.repositoryName}&new=true`,
@@ -152,13 +41,13 @@ describe('onRenderBody', () => {
   })
 
   test('expect Prismic Toolbar script to use the legacy URL if the `legacy` option is provided', async () => {
-    await onRenderBody!(mockGatsbyContext, {
+    await onRenderBody(mockGatsbyContext, {
       ...pluginOptions,
       prismicToolbar: 'legacy',
     })
 
     expect(
-      (mockGatsbyContext.setHeadComponents as jest.Mock).mock.calls[0][0][0]
+      (mockGatsbyContext.setPostBodyComponents as jest.Mock).mock.calls[0][0][0]
         .props.src,
     ).toBe(
       `//static.cdn.prismic.io/prismic.js?repo=${pluginOptions.repositoryName}`,

--- a/test/mergePrismicPreviewData.test.ts
+++ b/test/mergePrismicPreviewData.test.ts
@@ -1,31 +1,48 @@
 import { mergePrismicPreviewData } from '../src/mergePrismicPreviewData'
 
+const mockNode = {
+  id: 'id',
+  parent: '__SOURCE__',
+  children: [],
+  internal: {
+    type: 'MockNode',
+    contentDigest: 'contentDigest',
+    owner: 'owner',
+  },
+}
+
 const previewData = {
   prismicPage: {
+    ...mockNode,
     id: 'previewId',
     prismicId: 'prismicId',
     name: 'preview',
-    parent: '__SOURCE__',
-    children: [],
     internal: {
+      ...mockNode.internal,
       type: 'PrismicPage',
-      contentDigest: 'contentDigest',
-      owner: 'owner',
     },
   },
 }
 
 describe('mergePrismicPreviewData', () => {
   test('replaces static data with preview data', () => {
-    const staticData = { prismicPage: { name: 'static' } }
+    // TODO: Remove deprecation warning in v4.0.0.
+    const spy = jest.spyOn(console, 'warn')
+    spy.mockImplementation(() => {})
+
+    const staticData = { prismicPage: mockNode }
     const result = mergePrismicPreviewData({ staticData, previewData })
 
+    expect(spy.mock.calls[0][0]).toMatch(/deprecated/)
     expect(result).toEqual(previewData)
+
+    spy.mockReset()
   })
 
   test('replaces nested nodes with Prismic IDs matching preview data', () => {
     const staticData = {
       notPrismicPage: {
+        ...mockNode,
         object: { prismicId: previewData.prismicPage.prismicId },
         array: [
           { prismicId: previewData.prismicPage.prismicId },
@@ -46,7 +63,7 @@ describe('mergePrismicPreviewData', () => {
   })
 
   test('returns static data if no preview data', () => {
-    const staticData = { prismicPage: { name: 'static' } }
+    const staticData = { prismicPage: mockNode }
     const result = mergePrismicPreviewData({ staticData })
 
     expect(result).toBe(staticData)

--- a/test/mergePrismicPreviewData.test.ts
+++ b/test/mergePrismicPreviewData.test.ts
@@ -1,6 +1,7 @@
 import { mergePrismicPreviewData } from '../src/mergePrismicPreviewData'
 
 const mockNode = {
+  _previewable: 'id',
   id: 'id',
   parent: '__SOURCE__',
   children: [],
@@ -15,7 +16,6 @@ const previewData = {
   prismicPage: {
     ...mockNode,
     id: 'previewId',
-    prismicId: 'prismicId',
     name: 'preview',
     internal: {
       ...mockNode.internal,
@@ -30,7 +30,7 @@ describe('mergePrismicPreviewData', () => {
     const spy = jest.spyOn(console, 'warn')
     spy.mockImplementation(() => {})
 
-    const staticData = { prismicPage: mockNode }
+    const staticData = { prismicPage: { ...mockNode, _previewable: undefined } }
     const result = mergePrismicPreviewData({ staticData, previewData })
 
     expect(spy.mock.calls[0][0]).toMatch(/deprecated/)
@@ -43,9 +43,10 @@ describe('mergePrismicPreviewData', () => {
     const staticData = {
       notPrismicPage: {
         ...mockNode,
-        object: { prismicId: previewData.prismicPage.prismicId },
+        _previewable: 'noPrismicPageId',
+        object: { _previewable: previewData.prismicPage._previewable },
         array: [
-          { prismicId: previewData.prismicPage.prismicId },
+          { _previewable: previewData.prismicPage._previewable },
           { foo: 'bar' },
         ],
         foo: 'bar',

--- a/test/withPreview.test.tsx
+++ b/test/withPreview.test.tsx
@@ -1,0 +1,55 @@
+import * as React from 'react'
+import { render, screen } from '@testing-library/react'
+import { PageProps } from 'gatsby'
+
+import {
+  MOCK_PAGE_PROPS,
+  STATIC_DATA,
+  PREVIEW_DATA,
+  STATIC_UID,
+  PREVIEW_UID,
+} from './__fixtures__/pageData'
+
+import { PreviewStoreProvider, withPreview } from '../src'
+
+const Template = ({ data }: PageProps<typeof STATIC_DATA>) => (
+  <div data-testid="uid">{data.prismicPage.uid}</div>
+)
+Template.displayName = 'Template'
+
+const WrappedComponent = withPreview(Template)
+
+describe('withPreview', () => {
+  test('modifies displayName with `withPreview`', () => {
+    expect(WrappedComponent.displayName).toBe(
+      `withPreview(${Template.displayName})`,
+    )
+  })
+
+  test('renders static data if preview data is not available', () => {
+    render(
+      <PreviewStoreProvider initialEnabled={true}>
+        {/*
+         // @ts-ignore */}
+        <WrappedComponent {...MOCK_PAGE_PROPS} data={STATIC_DATA} />
+      </PreviewStoreProvider>,
+    )
+
+    expect(screen.getByTestId('uid')).toHaveTextContent(STATIC_UID)
+  })
+
+  test('renders preview data if preview data is available', () => {
+    render(
+      <PreviewStoreProvider
+        initialPages={{ [location.pathname]: PREVIEW_DATA }}
+        initialEnabled={true}
+      >
+        {/*
+         // @ts-ignore */}
+        <WrappedComponent {...MOCK_PAGE_PROPS} data={STATIC_DATA} />
+      </PreviewStoreProvider>,
+    )
+
+    expect(screen.getByTestId('uid')).toHaveTextContent(PREVIEW_UID)
+  })
+})

--- a/test/withPreviewResolver.test.tsx
+++ b/test/withPreviewResolver.test.tsx
@@ -1,0 +1,68 @@
+import * as React from 'react'
+import { render, screen } from '@testing-library/react'
+import { PageProps } from 'gatsby'
+import * as gatsby from 'gatsby'
+
+import { MOCK_PAGE_PROPS, STATIC_DATA } from './__fixtures__/pageData'
+
+import {
+  PreviewStoreProvider,
+  withPreviewResolver,
+  WithPreviewResolverProps,
+} from '../src'
+import { BROWSER_STORE_KEY } from '../src/constants'
+
+const navigateSpy = jest
+  .spyOn(gatsby, 'navigate')
+  .mockImplementation(async () => {})
+
+const Component = ({
+  isLoading,
+  isPreview,
+}: PageProps & WithPreviewResolverProps) => (
+  <>
+    <div data-testid="isLoading">{String(isLoading)}</div>
+    <div data-testid="isPreview">{String(isPreview)}</div>
+  </>
+)
+Component.displayName = 'Template'
+
+const WrappedComponent = withPreviewResolver(Component, {
+  repositoryName: 'repositoryName',
+  linkResolver: () => () => '/doc/',
+})
+
+window[BROWSER_STORE_KEY] = {
+  repositoryName: {
+    pluginOptions: {
+      plugins: [],
+      repositoryName: 'repositoryName',
+      schemas: {},
+    },
+    schemasDigest: 'schemasDigest',
+  },
+}
+
+describe('withPreviewResolver', () => {
+  test('modifies displayName with `withPreviewResolver`', () => {
+    expect(WrappedComponent.displayName).toBe(
+      `withPreviewResolver(${Component.displayName})`,
+    )
+  })
+
+  test('isPreview is false if not a preview', () => {
+    render(
+      <PreviewStoreProvider initialEnabled={true}>
+        {/*
+         // @ts-ignore */}
+        <WrappedComponent {...MOCK_PAGE_PROPS} data={STATIC_DATA} />
+      </PreviewStoreProvider>,
+    )
+
+    expect(screen.getByTestId('isPreview')).toHaveTextContent('false')
+    expect(screen.getByTestId('isLoading')).toHaveTextContent('false')
+    expect(navigateSpy).not.toHaveBeenCalled()
+  })
+
+  // TODO: Test when prevew data is available.
+})

--- a/test/withUnpublishedPreview.test.tsx
+++ b/test/withUnpublishedPreview.test.tsx
@@ -1,0 +1,59 @@
+import * as React from 'react'
+import { render, screen } from '@testing-library/react'
+import { PageProps } from 'gatsby'
+
+import {
+  MOCK_PAGE_PROPS,
+  STATIC_DATA,
+  PREVIEW_DATA,
+  PREVIEW_UID,
+} from './__fixtures__/pageData'
+
+import { PreviewStoreProvider, withUnpublishedPreview } from '../src'
+
+const Component = () => <div data-testid="content">Fallback</div>
+Component.displayName = 'Template'
+
+const Template = ({ data }: PageProps<typeof STATIC_DATA>) => (
+  <div data-testid="uid">{data.prismicPage.uid}</div>
+)
+Template.displayName = 'Template'
+
+const WrappedComponent = withUnpublishedPreview(Component, {
+  templateMap: { page: Template },
+})
+
+describe('withUnpublishedPreview', () => {
+  test('modifies displayName with `withUnpublishedPreview`', () => {
+    expect(WrappedComponent.displayName).toBe(
+      `withPreview(withUnpublishedPreview(${Component.displayName}))`,
+    )
+  })
+
+  test('renders fallback component if preview data is not available', () => {
+    render(
+      <PreviewStoreProvider initialEnabled={true}>
+        {/*
+         // @ts-ignore */}
+        <WrappedComponent {...MOCK_PAGE_PROPS} data={STATIC_DATA} />
+      </PreviewStoreProvider>,
+    )
+
+    expect(screen.getByTestId('content')).toHaveTextContent('Fallback')
+  })
+
+  test('renders preview data if preview data is available', () => {
+    render(
+      <PreviewStoreProvider
+        initialPages={{ [location.pathname]: PREVIEW_DATA }}
+        initialEnabled={true}
+      >
+        {/*
+         // @ts-ignore */}
+        <WrappedComponent {...MOCK_PAGE_PROPS} data={STATIC_DATA} />
+      </PreviewStoreProvider>,
+    )
+
+    expect(screen.getByTestId('uid')).toHaveTextContent(PREVIEW_UID)
+  })
+})

--- a/yarn.lock
+++ b/yarn.lock
@@ -971,6 +971,14 @@
     "@babel/helper-plugin-utils" "^7.10.1"
     "@babel/plugin-transform-typescript" "^7.10.1"
 
+"@babel/runtime-corejs3@^7.10.2":
+  version "7.10.4"
+  resolved "https://registry.yarnpkg.com/@babel/runtime-corejs3/-/runtime-corejs3-7.10.4.tgz#f29fc1990307c4c57b10dbd6ce667b27159d9e0d"
+  integrity sha512-BFlgP2SoLO9HJX9WBwN67gHWMBhDX/eDz64Jajd6mR/UAUzqrNMm99d4qHnVaKscAElZoFiPv+JpR/Siud5lXw==
+  dependencies:
+    core-js-pure "^3.0.0"
+    regenerator-runtime "^0.13.4"
+
 "@babel/runtime-corejs3@^7.8.3":
   version "7.10.2"
   resolved "https://registry.yarnpkg.com/@babel/runtime-corejs3/-/runtime-corejs3-7.10.2.tgz#3511797ddf9a3d6f3ce46b99cc835184817eaa4e"
@@ -983,6 +991,13 @@
   version "7.10.2"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.10.2.tgz#d103f21f2602497d38348a32e008637d506db839"
   integrity sha512-6sF3uQw2ivImfVIl62RZ7MXhO2tap69WeWK57vAaimT6AZbE4FbqjdEJIN1UqoD6wI6B+1n9UiagafH1sxjOtg==
+  dependencies:
+    regenerator-runtime "^0.13.4"
+
+"@babel/runtime@^7.10.2", "@babel/runtime@^7.10.3":
+  version "7.10.4"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.10.4.tgz#a6724f1a6b8d2f6ea5236dbfe58c7d7ea9c5eb99"
+  integrity sha512-UpTN5yUJr9b4EX2CnGNWIvER7Ab83ibv0pcvvHc4UOdrBI5jb8bj+32cCwPX6xu0mt2daFNjYhoi+X7beH0RSw==
   dependencies:
     regenerator-runtime "^0.13.4"
 
@@ -2150,6 +2165,33 @@
   dependencies:
     defer-to-connect "^1.0.1"
 
+"@testing-library/dom@^7.17.1":
+  version "7.20.0"
+  resolved "https://registry.yarnpkg.com/@testing-library/dom/-/dom-7.20.0.tgz#2bab85e90f0221a56256c5d4741c2a36b7c45f4d"
+  integrity sha512-TywaC+qDGm/Ro34kRYkFQPdT+pxSF4UjZGLIqcGfFQH5IGR43Y7sGLPnkieIW/GNsu337oxNsLUAgpI0JWhXHw==
+  dependencies:
+    "@babel/runtime" "^7.10.3"
+    "@types/aria-query" "^4.2.0"
+    aria-query "^4.2.2"
+    dom-accessibility-api "^0.4.5"
+    pretty-format "^25.5.0"
+
+"@testing-library/jest-dom@^5.11.0":
+  version "5.11.0"
+  resolved "https://registry.yarnpkg.com/@testing-library/jest-dom/-/jest-dom-5.11.0.tgz#1439f08dc85ce7c6d3bbad0ee5d53b2206f55768"
+  integrity sha512-mhaCySy7dZlyfcxcYy+0jLllODHEiHkVdmwQ00wD0HrWiSx0fSVHz/0WmdlRkvhfSOuqsRsBUreXOtBvruWGQA==
+  dependencies:
+    "@babel/runtime" "^7.9.2"
+    "@types/testing-library__jest-dom" "^5.9.1"
+    aria-query "^4.2.2"
+    chalk "^3.0.0"
+    css "^2.2.4"
+    css.escape "^1.5.1"
+    jest-diff "^25.1.0"
+    jest-matcher-utils "^25.1.0"
+    lodash "^4.17.15"
+    redent "^3.0.0"
+
 "@testing-library/react-hooks@^3.2.1":
   version "3.2.1"
   resolved "https://registry.yarnpkg.com/@testing-library/react-hooks/-/react-hooks-3.2.1.tgz#19b6caa048ef15faa69d439c469033873ea01294"
@@ -2157,6 +2199,15 @@
   dependencies:
     "@babel/runtime" "^7.5.4"
     "@types/testing-library__react-hooks" "^3.0.0"
+
+"@testing-library/react@^10.4.4":
+  version "10.4.4"
+  resolved "https://registry.yarnpkg.com/@testing-library/react/-/react-10.4.4.tgz#f05edf827df288c6c7b19fe96fff2b33cddbb809"
+  integrity sha512-SKDQ2jBdg9UQQYQragkvXOzNp4hnCdOvXyZ52rg+OXiiumVxkAutdvvRzBF4PrbvMQ27Z6gx0GVo2YQ1Mcip8g==
+  dependencies:
+    "@babel/runtime" "^7.10.3"
+    "@testing-library/dom" "^7.17.1"
+    semver "^7.3.2"
 
 "@theme-ui/color-modes@^0.4.0-highlight.0":
   version "0.4.0-highlight.0"
@@ -2214,6 +2265,11 @@
     "@theme-ui/color-modes" "^0.4.0-highlight.0"
     "@theme-ui/core" "^0.4.0-highlight.0"
     "@theme-ui/mdx" "^0.4.0-highlight.0"
+
+"@types/aria-query@^4.2.0":
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/@types/aria-query/-/aria-query-4.2.0.tgz#14264692a9d6e2fa4db3df5e56e94b5e25647ac0"
+  integrity sha512-iIgQNzCm0v7QMhhe4Jjn9uRh+I6GoPmt03CbEtwx3ao8/EfoQcmgtqH4vQ5Db/lxiIGaWDv6nwvunuh0RyX0+A==
 
 "@types/babel__core@^7.1.7":
   version "7.1.7"
@@ -2344,6 +2400,14 @@
   dependencies:
     "@types/istanbul-lib-coverage" "*"
     "@types/istanbul-lib-report" "*"
+
+"@types/jest@*":
+  version "26.0.3"
+  resolved "https://registry.yarnpkg.com/@types/jest/-/jest-26.0.3.tgz#79534e0e94857171c0edc596db0ebe7cb7863251"
+  integrity sha512-v89ga1clpVL/Y1+YI0eIu1VMW+KU7Xl8PhylVtDKVWaSUHBHYPLXMQGBdrpHewaKoTvlXkksbYqPgz8b4cmRZg==
+  dependencies:
+    jest-diff "^25.2.1"
+    pretty-format "^25.2.1"
 
 "@types/jest@^25.2.3":
   version "25.2.3"
@@ -2527,6 +2591,13 @@
   integrity sha512-hUieAt4sFS7zwbdU9Vlnn/c3vkfhTMhyiccYGpUSX96nJ4BF3NjLIjMu3cQOYS5EX4gPkHJZhkfdw41ov1NjhQ==
   dependencies:
     csstype "^2.6.6"
+
+"@types/testing-library__jest-dom@^5.9.1":
+  version "5.9.1"
+  resolved "https://registry.yarnpkg.com/@types/testing-library__jest-dom/-/testing-library__jest-dom-5.9.1.tgz#aba5ee062b7880f69c212ef769389f30752806e5"
+  integrity sha512-yYn5EKHO3MPEMSOrcAb1dLWY+68CG29LiXKsWmmpVHqoP5+ZRiAVLyUHvPNrO2dABDdUGZvavMsaGpWNjM6N2g==
+  dependencies:
+    "@types/jest" "*"
 
 "@types/testing-library__react-hooks@^3.0.0":
   version "3.2.0"
@@ -3084,6 +3155,14 @@ aria-query@^3.0.0:
   dependencies:
     ast-types-flow "0.0.7"
     commander "^2.11.0"
+
+aria-query@^4.2.2:
+  version "4.2.2"
+  resolved "https://registry.yarnpkg.com/aria-query/-/aria-query-4.2.2.tgz#0d2ca6c9aceb56b8977e9fed6aed7e15bbd2f83b"
+  integrity sha512-o/HelwhuKpTj/frsOsbNLNgnNGVIFsVP/SW2BSF14gVl7kAfMOJ6/8wUAUvG1R1NHKrfG+2sHZTu0yauT1qBrA==
+  dependencies:
+    "@babel/runtime" "^7.10.2"
+    "@babel/runtime-corejs3" "^7.10.2"
 
 arr-diff@^4.0.0:
   version "4.0.0"
@@ -5248,6 +5327,21 @@ css-what@^3.2.1:
   resolved "https://registry.yarnpkg.com/css-what/-/css-what-3.3.0.tgz#10fec696a9ece2e591ac772d759aacabac38cd39"
   integrity sha512-pv9JPyatiPaQ6pf4OvD/dbfm0o5LviWmwxNWzblYf/1u9QZd0ihV+PMwy5jdQWQ3349kZmKEx9WXuSka2dM4cg==
 
+css.escape@^1.5.1:
+  version "1.5.1"
+  resolved "https://registry.yarnpkg.com/css.escape/-/css.escape-1.5.1.tgz#42e27d4fa04ae32f931a4b4d4191fa9cddee97cb"
+  integrity sha1-QuJ9T6BK4y+TGktNQZH6nN3ul8s=
+
+css@^2.2.4:
+  version "2.2.4"
+  resolved "https://registry.yarnpkg.com/css/-/css-2.2.4.tgz#c646755c73971f2bba6a601e2cf2fd71b1298929"
+  integrity sha512-oUnjmWpy0niI3x/mPL8dVEI1l7MnG3+HHyRPHf+YFSbK+svOhXpmSOcDURUh2aOCgl2grzrOPt1nHLuCVFULLw==
+  dependencies:
+    inherits "^2.0.3"
+    source-map "^0.6.1"
+    source-map-resolve "^0.5.2"
+    urix "^0.1.0"
+
 cssesc@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/cssesc/-/cssesc-3.0.0.tgz#37741919903b868565e1c09ea747445cd18983ee"
@@ -5752,6 +5846,11 @@ doctrine@^3.0.0:
   integrity sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==
   dependencies:
     esutils "^2.0.2"
+
+dom-accessibility-api@^0.4.5:
+  version "0.4.5"
+  resolved "https://registry.yarnpkg.com/dom-accessibility-api/-/dom-accessibility-api-0.4.5.tgz#d9c1cefa89f509d8cf132ab5d250004d755e76e3"
+  integrity sha512-HcPDilI95nKztbVikaN2vzwvmv0sE8Y2ZJFODy/m15n7mGXLeOKGiys9qWVbFbh+aq/KYj2lqMLybBOkYAEXqg==
 
 dom-converter@^0.2:
   version "0.2.0"
@@ -9465,7 +9564,7 @@ jest-config@^26.0.1:
     micromatch "^4.0.2"
     pretty-format "^26.0.1"
 
-jest-diff@^25.2.1, jest-diff@^25.5.0:
+jest-diff@^25.1.0, jest-diff@^25.2.1, jest-diff@^25.5.0:
   version "25.5.0"
   resolved "https://registry.yarnpkg.com/jest-diff/-/jest-diff-25.5.0.tgz#1dd26ed64f96667c068cef026b677dfa01afcfa9"
   integrity sha512-z1kygetuPiREYdNIumRpAHY6RXiGmp70YHptjdaxTWGmA085W3iCnXNx0DhflK3vwrKmrRWyY1wUpkPMVxMK7A==
@@ -9586,6 +9685,16 @@ jest-leak-detector@^26.0.1:
   dependencies:
     jest-get-type "^26.0.0"
     pretty-format "^26.0.1"
+
+jest-matcher-utils@^25.1.0:
+  version "25.5.0"
+  resolved "https://registry.yarnpkg.com/jest-matcher-utils/-/jest-matcher-utils-25.5.0.tgz#fbc98a12d730e5d2453d7f1ed4a4d948e34b7867"
+  integrity sha512-VWI269+9JS5cpndnpCwm7dy7JtGQT30UHfrnM3mXl22gHGt/b7NkjBqXfbhZ8V4B7ANUsjK18PlSBmG0YH7gjw==
+  dependencies:
+    chalk "^3.0.0"
+    jest-diff "^25.5.0"
+    jest-get-type "^25.2.6"
+    pretty-format "^25.5.0"
 
 jest-matcher-utils@^26.0.1:
   version "26.0.1"
@@ -14162,7 +14271,7 @@ source-list-map@^2.0.0:
   resolved "https://registry.yarnpkg.com/source-list-map/-/source-list-map-2.0.1.tgz#3993bd873bfc48479cca9ea3a547835c7c154b34"
   integrity sha512-qnQ7gVMxGNxsiL4lEuJwe/To8UnK7fAnmbGEEH8RpLouuKbeEm0lhbQVFIrNSuB+G7tVrAlVsZgETT5nljf+Iw==
 
-source-map-resolve@^0.5.0:
+source-map-resolve@^0.5.0, source-map-resolve@^0.5.2:
   version "0.5.3"
   resolved "https://registry.yarnpkg.com/source-map-resolve/-/source-map-resolve-0.5.3.tgz#190866bece7553e1f8f267a2ee82c606b5509a1a"
   integrity sha512-Htz+RnsXWk5+P2slx5Jh3Q66vhQj1Cllm0zvnaY98+NFx+Dv2CF/f5O/t8x+KaNdrdIAsruNzoh/KpialbqAnw==


### PR DESCRIPTION
See #246 for more details on why this change is needed and how it works.

This adds an option to `mergePrismicPreviewData` to decide which merge strategy to use. This change coincides with the decision to enforce the traverse strategy for all previews.