### PR TITLE
fix: support repositories without image fields

### DIFF
--- a/src/gatsby-node.ts
+++ b/src/gatsby-node.ts
@@ -49,13 +49,14 @@ export const sourceNodes: NonNullable<GatsbyNode['sourceNodes']> = async (
     pluginOptions.schemas,
     gatsbyContext,
   )
-  const imageTypes = buildPrismicImageTypes({
+  const [imgixImageTypes, imageTypes] = buildPrismicImageTypes({
     schema,
     cache,
     defaultImgixParams: pluginOptions.imageImgixParams,
     defaultPlaceholderImgixParams: pluginOptions.imagePlaceholderImgixParams,
   })
   createTypes(typeDefs)
+  createTypes(imgixImageTypes)
   createTypes(imageTypes)
   createTypes(types)
 

--- a/src/gqlTypes.ts
+++ b/src/gqlTypes.ts
@@ -116,7 +116,15 @@ export const buildPrismicImageTypes = ({
     },
   })
 
-  return [PrismicImageType, PrismicImageThumbnailType]
+  // The following types must be separated to in order to pass them separately
+  // to two different `createTypes` calls in gatsby-node.ts. `createTypes`
+  // requires that all passed types are of the same class.
+  return [
+    // Imgix GraphQLObjectType instances
+    [PrismicImageFixedType, PrismicImageFluidType],
+    // Prismic GatsbyGraphQLObjectType instances
+    [PrismicImageType, PrismicImageThumbnailType],
+  ]
 }
 
 const gql = (query: TemplateStringsArray) => String(query).replace(`\n`, ` `)

--- a/test/__snapshots__/gatsby-node.test.ts.snap
+++ b/test/__snapshots__/gatsby-node.test.ts.snap
@@ -407,6 +407,12 @@ exports[`sourceNodes creates types 1`] = `
     ],
     Array [
       Array [
+        "PrismicImageFixedType",
+        "PrismicImageFluidType",
+      ],
+    ],
+    Array [
+      Array [
         Object {
           "config": Object {
             "description": "An image field with optional constrained thumbnails.",
@@ -749,6 +755,10 @@ exports[`sourceNodes creates types 1`] = `
     ],
   ],
   "results": Array [
+    Object {
+      "type": "return",
+      "value": undefined,
+    },
     Object {
       "type": "return",
       "value": undefined,


### PR DESCRIPTION
The new `gatsby-plugin-imgix` types were being used without passing them to Gatsby's `createTypes` Node API. Now that it is passed to `createTypes`, the GraphQL system knows the type even if none of the repository's schemas contain an image field.

Fixes #238