### PR TITLE
fix: Preview docs, unpublished code example

### DIFF
--- a/docs/previews.md
+++ b/docs/previews.md
@@ -172,7 +172,7 @@ const NotFoundPage = () => (
 )
 
 // If an unpublished `page` document is previewed, PageTemplate will be rendered.
-export default withUnpublishedPreview(PreviewPage, {
+export default withUnpublishedPreview(NotFoundPage, {
   templateMap: {
     page: PageTemplate,
     blog_post: BlogPostTemplate,


### PR DESCRIPTION
I believe the exported page should be `NotFoundPage` rather than `PreviewPage` which is not in the scope.