### PR TITLE
docs(previews): add prismicId reference & comments

### DIFF
--- a/docs/previews-manual-setup.md
+++ b/docs/previews-manual-setup.md
@@ -344,6 +344,10 @@ For this example, let's assume we navigated to a page generated using a template
 at `src/templates/page.js`. If your site uses a static page or a different
 template, these changes will go there instead.
 
+In order to preview changes for both unpublished and published documents, the
+property `prismicId` must be included in the root of the GraphQL query. Querys
+without the `prismicId` property will only work for unpublished documents.
+
 ```javascript
 // src/templates/page.js
 import React from 'react'
@@ -368,6 +372,7 @@ export const PageTemplate = ({ data }) => {
 export const query = graphql`
   query($id: String!) {
     prismicPage(id: { eq: $id }) {
+      prismicId
       data {
         title
         body {

--- a/docs/previews.md
+++ b/docs/previews.md
@@ -58,6 +58,10 @@ The `withPreview` HOC automatically merges preview data with Gatsby's static
 data in the `data` page prop. By using `withPreview`, your page components do
 not need to be written in a special way to take advantage of Prismic Previews.
 
+In order to preview changes for both unpublished and published documents, the
+`prismicId` property must be included in the root of the GraphQL query. Querys
+without the `prismicId` property will only work for unpublished documents.
+
 To use `withPreview`, wrap the `export default` with `withPreview` like the
 following:
 
@@ -82,6 +86,7 @@ export default withPreview(PageTemplate)
 export const query = graphql`
   query PageTemplate($uid: String!) {
     prismicPage(uid: { eq: $uid }) {
+      prismicId
       data {
         title {
           text


### PR DESCRIPTION
resolves #245

Hey @angeloashmore  👋

As discussed in #245 there has been some confusion around the undocumented property `prismicId` which is required to be included in a GraphQL page/template query in order to view previews for published documents.

I have updated the preview documentation to include a note on this requirement and also included the property in the example queries. Hopefully this is sufficent but if you'd prefer to handle this update yourself, no problem! 