### PR TITLE
Implement graphquery

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,15 @@ plugins: [
         // Your list of links
       ],
 
+      // Specify which fields to retrieve and what content to retrieve from Linked 
+      // Documents / Content Relationships. This replaces fetchLinks.
+      // See: https://prismic.io/docs/rest-api/query-the-api/graphquery
+      graphQuery: `{
+        blog {
+          ...blogFields
+        }
+      }`
+
       // Set an HTML serializer function used to process formatted content.
       // Fields with rich text formatting use this function to generate the
       // correct HTML.

--- a/src/api.ts
+++ b/src/api.ts
@@ -52,6 +52,7 @@ export const fetchAllDocuments = async (
     releaseID,
     accessToken,
     fetchLinks,
+    graphQuery,
     lang,
   } = pluginOptions
   const { reporter } = gatsbyContext
@@ -72,6 +73,7 @@ export const fetchAllDocuments = async (
     }
   }
   if (fetchLinks) queryOptions.fetchLinks = fetchLinks
+  if (graphQuery) queryOptions.graphQuery = graphQuery
   if (lang) queryOptions.lang = lang
 
   return await pagedGet(client, queryOptions, 1, API_PAGE_SIZE, [], reporter)

--- a/src/environment.browser.ts
+++ b/src/environment.browser.ts
@@ -50,7 +50,7 @@ const loadLinkFieldDocument = async (
     return
 
   const { hasNodeById } = context as DocumentsToNodesEnvironmentBrowserContext
-  const { repositoryName, accessToken, fetchLinks } = pluginOptions
+  const { repositoryName, accessToken, fetchLinks, graphQuery } = pluginOptions
 
   const linkedDocId = createNodeId(`${field.type} ${field.id}`)
 
@@ -70,6 +70,7 @@ const loadLinkFieldDocument = async (
 
   const queryOptions: QueryOptions = {}
   if (fetchLinks) queryOptions.fetchLinks = fetchLinks
+  if (graphQuery) queryOptions.graphQuery = graphQuery
 
   // Query Prismic's API for the document.
   const client = await createClient(repositoryName, accessToken)

--- a/src/types.ts
+++ b/src/types.ts
@@ -346,6 +346,7 @@ export type BrowserPluginOptions = GatsbyPluginOptions &
     | 'repositoryName'
     | 'accessToken'
     | 'fetchLinks'
+    | 'graphQuery'
     | 'schemas'
     | 'lang'
     | 'typePathsFilenamePrefix'
@@ -359,6 +360,7 @@ export interface PluginOptions extends GatsbyPluginOptions {
   linkResolver?: PluginLinkResolver
   htmlSerializer?: PluginHTMLSerializer
   fetchLinks?: string[]
+  graphQuery?: string
   schemas: Schemas
   lang?: string
   shouldDownloadImage?: ShouldDownloadImage

--- a/src/usePrismicPreview.ts
+++ b/src/usePrismicPreview.ts
@@ -25,6 +25,7 @@ export type UsePrismicPreviewOptions = Pick<
   | 'linkResolver'
   | 'htmlSerializer'
   | 'fetchLinks'
+  | 'graphQuery'
   | 'lang'
   | 'typePathsFilenamePrefix'
 > & {
@@ -151,6 +152,9 @@ export const usePrismicPreview = (options: UsePrismicPreviewOptions) => {
     const queryOptions: QueryOptions = {}
     if (hydratedOptions.fetchLinks)
       queryOptions.fetchLinks = hydratedOptions.fetchLinks
+
+    if (hydratedOptions.graphQuery)
+      queryOptions.graphQuery = hydratedOptions.graphQuery
 
     // Query Prismic's API for the document.
     const client = await createClient(

--- a/src/validateOptions.ts
+++ b/src/validateOptions.ts
@@ -10,6 +10,7 @@ const baseSchema = {
   linkResolver: struct.defaulted(struct.func(), () => () => () => {}),
   htmlSerializer: struct.defaulted(struct.func(), () => () => () => {}),
   fetchLinks: struct.defaulted(struct.array(struct.string()), []),
+  graphQuery: struct.defaulted(struct.string(), '*'),
   lang: struct.defaulted(struct.string(), '*'),
   typePathsFilenamePrefix: struct.defaulted(
     struct.string(),

--- a/src/validateOptions.ts
+++ b/src/validateOptions.ts
@@ -10,7 +10,7 @@ const baseSchema = {
   linkResolver: struct.defaulted(struct.func(), () => () => () => {}),
   htmlSerializer: struct.defaulted(struct.func(), () => () => () => {}),
   fetchLinks: struct.defaulted(struct.array(struct.string()), []),
-  graphQuery: struct.defaulted(struct.string(), '*'),
+  graphQuery: struct.optional(struct.string()),
   lang: struct.defaulted(struct.string(), '*'),
   typePathsFilenamePrefix: struct.defaulted(
     struct.string(),


### PR DESCRIPTION
This adds GraphQuery to gatsby-source-prismic. Resolves: #267 

Tested with my own project and appears to work as expected.