### PR TITLE
WIP: custom types api

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "pascal-case": "^3.1.1",
     "prismic-dom": "^2.2.3",
     "prismic-javascript": "^2.7.1",
-    "superstruct": "^0.10.12",
+    "superstruct": "^0.14.0",
     "uuid": "^8.2.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -17,8 +17,8 @@
   ],
   "scripts": {
     "clean": "rimraf ./dist",
-    "start": "yarn clean && microbundle watch src/index.ts src/gatsby-node.ts src/gatsby-browser.ts src/gatsby-ssr.ts -o dist -f modern,cjs --jsx React.createElement",
-    "build": "yarn clean && microbundle build src/index.ts src/gatsby-node.ts src/gatsby-browser.ts src/gatsby-ssr.ts -o dist -f modern,cjs --jsx React.createElement",
+    "start": "yarn clean && microbundle watch src/index.ts src/gatsby-node.ts src/gatsby-browser.ts src/gatsby-ssr.ts -o dist -f modern,cjs --jsx React.createElement --target node",
+    "build": "yarn clean && microbundle build src/index.ts src/gatsby-node.ts src/gatsby-browser.ts src/gatsby-ssr.ts -o dist -f modern,cjs --jsx React.createElement --target node",
     "format": "prettier --write '{src,docs}/**/*.{ts,tsx,md}'",
     "test": "jest",
     "prepare": "yarn build",

--- a/src/gatsby-browser.ts
+++ b/src/gatsby-browser.ts
@@ -36,8 +36,9 @@ export const onClientEntry: GatsbyBrowser['onClientEntry'] = (
 
   window[BROWSER_STORE_KEY] = Object.assign({}, window[BROWSER_STORE_KEY], {
     [pluginOptions.repositoryName]: {
-      pluginOptions: omit(pluginOptions, ['schemas', 'plugins']),
-      schemasDigest: md5(JSON.stringify(pluginOptions.schemas)),
+      pluginOptions: omit(pluginOptions, ['schemas', 'plugins', 'customTypeToken']),
+      //TODO: find out what's this for
+      schemasDigest: md5(JSON.stringify(pluginOptions.schemas || {})),
     },
   })
 }

--- a/src/gatsby-node.ts
+++ b/src/gatsby-node.ts
@@ -27,7 +27,6 @@ export const createSchemaCustomization: NonNullable<
   pluginOptions: PluginOptions,
 ) => {
   const schemas = pluginOptions.customTypeToken ? await getCustomTypes(pluginOptions) : pluginOptions.schemas // TODO: this is repeated else where
-  console.dir({schemas}, {depth: null})
   const { typeDefs } = schemasToTypeDefs(schemas, args)
 
   createPrismicTypes(pluginOptions, args, typeDefs)

--- a/src/gatsby-node.ts
+++ b/src/gatsby-node.ts
@@ -18,6 +18,7 @@ import {
 } from 'gatsby'
 import { PluginOptions, TypePath, PrismicWebhook } from './types'
 import { isPrismicWebhook, validateSecret, handleWebhook } from './webhook'
+import {getCustomTypes} from './api'
 
 export const createSchemaCustomization: NonNullable<
   GatsbyNode['createSchemaCustomization']
@@ -25,7 +26,9 @@ export const createSchemaCustomization: NonNullable<
   args: CreateSchemaCustomizationArgs,
   pluginOptions: PluginOptions,
 ) => {
-  const { typeDefs } = schemasToTypeDefs(pluginOptions.schemas, args)
+  const schemas = pluginOptions.customTypeToken ? await getCustomTypes(pluginOptions) : pluginOptions.schemas // TODO: this is repeated else where
+  console.dir({schemas}, {depth: null})
+  const { typeDefs } = schemasToTypeDefs(schemas, args)
 
   createPrismicTypes(pluginOptions, args, typeDefs)
 }
@@ -152,8 +155,10 @@ export const sourceNodes: NonNullable<GatsbyNode['sourceNodes']> = async (
     reporter.panic(error)
   }
 
+  const schemas = pluginOptions.customTypeToken ? await getCustomTypes(pluginOptions) : pluginOptions.schemas // TODO: this is repeated else where, maybe cache them?
+
   const { typePaths } = schemasToTypeDefs(
-    pluginOptions.schemas,
+    schemas,
     (gatsbyContext as unknown) as CreateSchemaCustomizationArgs,
   )
 

--- a/src/gatsby-node.ts
+++ b/src/gatsby-node.ts
@@ -96,7 +96,7 @@ const buildAll = async (
   createNodesActivity.end()
 }
 
-const writeTypePaths = (
+const writeTypePaths = async (
   pluginOptions: PluginOptions,
   gatsbyContext: SourceNodesArgs,
   typePaths: TypePath[],
@@ -115,7 +115,10 @@ const writeTypePaths = (
 
   reporter.verbose(msg('starting to write out type paths'))
 
-  const schemasDigest = md5(JSON.stringify(pluginOptions.schemas))
+  const schemas = pluginOptions.customTypeToken ? await getCustomTypes(pluginOptions) : pluginOptions.schemas || {} // TODO: this is repeated else where
+
+  // what are these made public for?
+  const schemasDigest = md5(JSON.stringify(schemas))
   const typePathsFilename = path.resolve(
     program.directory,
     'public',
@@ -164,7 +167,8 @@ export const sourceNodes: NonNullable<GatsbyNode['sourceNodes']> = async (
   if (!webhookBody || JSON.stringify(webhookBody) === '{}') {
     /** Initial build or rebuild everything */
     await buildAll(pluginOptions, gatsbyContext, typePaths)
-    writeTypePaths(pluginOptions, gatsbyContext, typePaths, program)
+    // TODO: what happens when a new custom-types is added?
+    await writeTypePaths(pluginOptions, gatsbyContext, typePaths, program)
   } else if (
     isPrismicWebhook(webhookBody) &&
     validateSecret(pluginOptions, webhookBody)

--- a/src/gatsby-node.ts
+++ b/src/gatsby-node.ts
@@ -26,7 +26,7 @@ export const createSchemaCustomization: NonNullable<
   args: CreateSchemaCustomizationArgs,
   pluginOptions: PluginOptions,
 ) => {
-  const schemas = pluginOptions.customTypeToken ? await getCustomTypes(pluginOptions) : pluginOptions.schemas // TODO: this is repeated else where
+  const schemas = pluginOptions.customTypeToken ? await getCustomTypes(pluginOptions) : pluginOptions.schemas || {} // TODO: this is repeated else where
   const { typeDefs } = schemasToTypeDefs(schemas, args)
 
   createPrismicTypes(pluginOptions, args, typeDefs)
@@ -154,7 +154,7 @@ export const sourceNodes: NonNullable<GatsbyNode['sourceNodes']> = async (
     reporter.panic(error)
   }
 
-  const schemas = pluginOptions.customTypeToken ? await getCustomTypes(pluginOptions) : pluginOptions.schemas // TODO: this is repeated else where, maybe cache them?
+  const schemas = pluginOptions.customTypeToken ? await getCustomTypes(pluginOptions) : pluginOptions.schemas || {}// TODO: this is repeated else where, maybe cache them?
 
   const { typePaths } = schemasToTypeDefs(
     schemas,

--- a/src/types.ts
+++ b/src/types.ts
@@ -359,7 +359,7 @@ export interface PluginOptions extends GatsbyPluginOptions {
   linkResolver?: PluginLinkResolver
   htmlSerializer?: PluginHTMLSerializer
   fetchLinks?: string[]
-  schemas: Schemas
+  schemas?: Schemas
   lang?: string
   shouldDownloadImage?: ShouldDownloadImage
   shouldNormalizeImage?: ShouldDownloadImage
@@ -368,6 +368,7 @@ export interface PluginOptions extends GatsbyPluginOptions {
   imageImgixParams?: ImgixUrlParams
   imagePlaceholderImgixParams?: ImgixUrlParams
   webhookSecret?: string
+  customTypeToken?: string
 }
 
 export interface WebhookBase {

--- a/src/usePrismicPreview.ts
+++ b/src/usePrismicPreview.ts
@@ -97,7 +97,7 @@ export const usePrismicPreview = (options: UsePrismicPreviewOptions) => {
   // @ts-expect-error
   const hydratedOptions: UsePrismicPreviewOptions & {
     plugins: []
-    schemas: {}
+    // schemas: {}
     lang: string
     typePathsFilenamePrefix: string
     schemasDigest: string
@@ -116,7 +116,7 @@ export const usePrismicPreview = (options: UsePrismicPreviewOptions) => {
       schemasDigest: context.schemasDigest,
       // Need to include an empty object because environment.browser.ts is
       // expecting it. We do not include the actual schemas in the browser.
-      schemas: {},
+      // schemas: {},
       ...options,
     })
   }, [options])

--- a/src/validateOptions.ts
+++ b/src/validateOptions.ts
@@ -2,12 +2,13 @@ import * as struct from 'superstruct'
 
 import { PluginOptions, BrowserPluginOptions } from './types'
 
+
 const baseSchema = {
   repositoryName: struct.string(),
   accessToken: struct.optional(struct.string()),
-  customTypeToken: struct.optional(struct.string()), // TODO: Maybe rename
   releaseID: struct.optional(struct.string()),
-  schemas: struct.record(struct.string(), struct.object()), // TODO: should this be mandatory if customTypeToken is given.
+  // customTypeToken: struct.string(),
+  schemas: struct.record(struct.string(), struct.object()),
   linkResolver: struct.defaulted(struct.func(), () => () => () => {}),
   htmlSerializer: struct.defaulted(struct.func(), () => () => () => {}),
   fetchLinks: struct.defaulted(struct.array(struct.string()), []),
@@ -48,6 +49,7 @@ const PluginOptions = struct.object({
     () => () => false,
   ),
   webhookSecret: struct.optional(struct.string()),
+  customTypeToken: struct.string(),
 })
 
 const BrowserPluginOptions = struct.object({
@@ -57,15 +59,19 @@ const BrowserPluginOptions = struct.object({
 })
 
 export const validatePluginOptions = (pluginOptions: PluginOptions) => {
-  const coerced = struct.coerce(pluginOptions, PluginOptions)
-  struct.assert(coerced, PluginOptions)
+  // This could be done better
+  const schemasOrTypeToken = struct.omit(PluginOptions, pluginOptions.customTypeToken ? ['schemas'] : ['customTypeToken'])
+  const coerced = struct.create(pluginOptions, schemasOrTypeToken)
+  struct.assert(coerced, schemasOrTypeToken)
   return (coerced as unknown) as PluginOptions
 }
 
 export const validateBrowserOptions = (
   browserOptions: BrowserPluginOptions,
 ) => {
-  const coerced = struct.coerce(browserOptions, BrowserPluginOptions)
+  // needed although I don't think schemas or customTypes token are passed to the browser ?
+  // const schemasOrTypeToken = struct.omit(BrowserPluginOptions, ['schemas'])
+  const coerced = struct.create(browserOptions, BrowserPluginOptions)
   struct.assert(coerced, BrowserPluginOptions)
   return (coerced as unknown) as BrowserPluginOptions
 }

--- a/src/validateOptions.ts
+++ b/src/validateOptions.ts
@@ -7,8 +7,6 @@ const baseSchema = {
   repositoryName: struct.string(),
   accessToken: struct.optional(struct.string()),
   releaseID: struct.optional(struct.string()),
-  // customTypeToken: struct.string(),
-  schemas: struct.record(struct.string(), struct.object()),
   linkResolver: struct.defaulted(struct.func(), () => () => () => {}),
   htmlSerializer: struct.defaulted(struct.func(), () => () => () => {}),
   fetchLinks: struct.defaulted(struct.array(struct.string()), []),
@@ -44,12 +42,14 @@ const baseSchema = {
 
 const PluginOptions = struct.object({
   ...baseSchema,
+  
   shouldDownloadImage: struct.defaulted(
     struct.optional(struct.func()),
     () => () => false,
   ),
   webhookSecret: struct.optional(struct.string()),
   customTypeToken: struct.string(),
+  schemas: struct.record(struct.string(), struct.object()),
 })
 
 const BrowserPluginOptions = struct.object({

--- a/src/validateOptions.ts
+++ b/src/validateOptions.ts
@@ -5,8 +5,9 @@ import { PluginOptions, BrowserPluginOptions } from './types'
 const baseSchema = {
   repositoryName: struct.string(),
   accessToken: struct.optional(struct.string()),
+  customTypeToken: struct.optional(struct.string()), // TODO: Maybe rename
   releaseID: struct.optional(struct.string()),
-  schemas: struct.record(struct.string(), struct.object()),
+  schemas: struct.record(struct.string(), struct.object()), // TODO: should this be mandatory if customTypeToken is given.
   linkResolver: struct.defaulted(struct.func(), () => () => () => {}),
   htmlSerializer: struct.defaulted(struct.func(), () => () => () => {}),
   fetchLinks: struct.defaulted(struct.array(struct.string()), []),

--- a/src/webhook.ts
+++ b/src/webhook.ts
@@ -19,6 +19,7 @@ export function validateSecret(
   return pluginOptions.webhookSecret === webhookBody.secret
 }
 
+// TODO: pretty sure this is defined else where
 export function isPrismicUrl(url: string | undefined): boolean {
   if (!url) return false
   const regexp = /^https?:\/\/([^.]+)\.(wroom\.(?:test|io)|prismic\.io)\/api\/?/

--- a/test/validateOptions.test.ts
+++ b/test/validateOptions.test.ts
@@ -1,0 +1,64 @@
+import {validatePluginOptions} from '../src/validateOptions'
+import {PluginOptions} from '../src/types'
+
+describe('validatePlugOptions', () => {
+  describe('mandatory options', () => {
+
+    const defaults = {
+      linkResolver: expect.any(Function),
+      htmlSerializer: expect.any(Function),
+      accessToken: undefined,
+      customTypeToken: undefined,
+      fetchLinks: [],
+      lang: '*',
+      typePathsFilenamePrefix: 'prismic-typepaths---',
+      prismicToolbar: false,
+      releaseID: undefined,
+      imageImgixParams: { auto: 'format,compress', fit: 'max', q: 50 },
+      imagePlaceholderImgixParams: { w: 100, blur: 15, q: 20 },
+      plugins: [],
+      shouldDownloadImage: expect.any(Function),
+      webhookSecret: undefined,
+     }
+
+    it('can have repository name and schemas', () => {
+      const opts = {
+        repositoryName: 'example',
+        schemas: {},
+      } as PluginOptions
+
+      const result = validatePluginOptions(opts)
+
+      expect(result).toEqual({...defaults, ...opts})
+    })
+
+    it('can have repository name and customTypeToken', () => {
+      const opts = {
+        repositoryName: 'example-custom-types',
+        customTypeToken: 'qwerty',
+      } as PluginOptions
+
+      const result = validatePluginOptions(opts)
+
+      expect(result).toEqual({...defaults, ...opts})
+    })
+
+    it('should throw an error when nether customTypeToken or schemas are provided', () => {
+
+      const opts = {
+        repositoryName: 'exmpale-missing-types',
+      } as PluginOptions
+
+      expect(() => validatePluginOptions(opts)).toThrow()
+    })
+
+    it('should throw an error if repositoyName is not provided', () => {
+
+      const opts = {
+        schemas: {},
+      } as PluginOptions
+
+      expect(() => validatePluginOptions(opts)).toThrow()
+    })
+  })
+})

--- a/test/withPreviewResolver.test.tsx
+++ b/test/withPreviewResolver.test.tsx
@@ -37,7 +37,7 @@ window[BROWSER_STORE_KEY] = {
     pluginOptions: {
       plugins: [],
       repositoryName: 'repositoryName',
-      schemas: {},
+      // schemas: {},
     },
     schemasDigest: 'schemasDigest',
   },


### PR DESCRIPTION
There's a custom-types api in staged that enables custom-types to be downloaded rather than copy and pasted.

This branch is s prototype for downloading the custom-types.

There are a few topics that need to be addressed.

+ The api is called multiple times during the build process, maybe they should be added to the cache.
+ Validating plugin options require superstruct to be updated.
+ Are the custom-types needed client side for previews? I saw that the schema digest is passed to the client so it maybe required that the custom-types are made public.
+ Who should custom-type updates be handled when running is production.... the information is provided in a the webhook and can be fetched (all in one or one at a time). 

@angeloashmore do think? also should this PR be re-worked for v4?

Note this is still a work in progress as the API may change.