### PR TITLE
fix: add video_id to oembed for issue #286

### DIFF
--- a/src/gqlTypes.ts
+++ b/src/gqlTypes.ts
@@ -190,6 +190,8 @@ export const types = gql`
     media_id: ID
     "A description for the resource."
     description: String
+    "The ID of a video. from viemo"
+    video_id: ID
   }
 
   "Dimensions for images."

--- a/test/__snapshots__/gatsby-node.test.ts.snap
+++ b/test/__snapshots__/gatsby-node.test.ts.snap
@@ -639,6 +639,8 @@ exports[`sourceNodes creates types 1`] = `
     media_id: ID
     \\"A description for the resource.\\"
     description: String
+    \\"The ID of a video. from viemo\\"
+    video_id: ID
   }
 
   \\"Dimensions for images.\\"


### PR DESCRIPTION
#286 

video_id seems to be vimeo specific field, this may confuse users who youtube or an other video source and the field would be null. 