### PR TITLE
feat: transformFieldName option to support dashes in field names

### DIFF
--- a/packages/gatsby-plugin-prismic-previews/docs/api-withPrismicPreview.md
+++ b/packages/gatsby-plugin-prismic-previews/docs/api-withPrismicPreview.md
@@ -50,6 +50,11 @@ in your app:
   for the configured Prismic repository. This should be the same HTML Serializer
   provided to [`gatsby-source-prismic`][gsp] in your app's `gatsby-config.js`.
 
+- **`transformFieldName`**<br/>The optional field transformer for the configured
+  Prismic repository. This should be the same `transformFieldName` function
+  provided to [`gatsby-source-prismic`][gsp] in your app's `gatsby-config.js` if
+  used. Most project will not need to provide a value for this option.
+
 Configuration values:
 
 - **`mergePreviewData`**<br/>An optional boolean that determines if previewed

--- a/packages/gatsby-plugin-prismic-previews/docs/api-withPrismicPreview.md
+++ b/packages/gatsby-plugin-prismic-previews/docs/api-withPrismicPreview.md
@@ -53,7 +53,7 @@ in your app:
 - **`transformFieldName`**<br/>The optional field transformer for the configured
   Prismic repository. This should be the same `transformFieldName` function
   provided to [`gatsby-source-prismic`][gsp] in your app's `gatsby-config.js` if
-  used. Most project will not need to provide a value for this option.
+  used. Most projects will not need to provide a value for this option.
 
 Configuration values:
 

--- a/packages/gatsby-plugin-prismic-previews/src/fieldProxies/documentDataFieldProxy.ts
+++ b/packages/gatsby-plugin-prismic-previews/src/fieldProxies/documentDataFieldProxy.ts
@@ -7,7 +7,7 @@ import {
   proxyDocumentSubtree,
   ProxyDocumentSubtreeEnv,
 } from '../lib/proxyDocumentSubtree'
-import { mapRecordIndicies } from '../lib/mapRecordIndices'
+import { mapRecordIndices } from '../lib/mapRecordIndices'
 
 export const valueRefinement = (value: unknown): value is UnknownRecord =>
   typeof value === 'object' && value !== null
@@ -21,7 +21,7 @@ export const proxyValue = (
     RE.chain((env) =>
       pipe(
         fieldValue,
-        mapRecordIndicies(env.transformFieldName),
+        mapRecordIndices(env.transformFieldName),
         R.mapWithIndex((fieldName, value) =>
           proxyDocumentSubtree([...path, fieldName], value),
         ),

--- a/packages/gatsby-plugin-prismic-previews/src/lib/defaultFieldTransformer.ts
+++ b/packages/gatsby-plugin-prismic-previews/src/lib/defaultFieldTransformer.ts
@@ -1,0 +1,2 @@
+export const defaultFieldTransformer = (fieldName: string): string =>
+  fieldName.replace(/-/g, '_')

--- a/packages/gatsby-plugin-prismic-previews/src/lib/mapRecordIndices.ts
+++ b/packages/gatsby-plugin-prismic-previews/src/lib/mapRecordIndices.ts
@@ -3,7 +3,7 @@ import * as A from 'fp-ts/Array'
 import * as S from 'fp-ts/Semigroup'
 import { flow } from 'fp-ts/function'
 
-export const mapRecordIndicies = <K extends string, A>(
+export const mapRecordIndices = <K extends string, A>(
   f: (k: K) => string,
 ): ((r: Record<K, A>) => Record<string, A>) =>
   flow(

--- a/packages/gatsby-plugin-prismic-previews/src/lib/mapRecordIndices.ts
+++ b/packages/gatsby-plugin-prismic-previews/src/lib/mapRecordIndices.ts
@@ -1,0 +1,16 @@
+import * as R from 'fp-ts/Record'
+import * as A from 'fp-ts/Array'
+import * as S from 'fp-ts/Semigroup'
+import { flow } from 'fp-ts/function'
+
+export const mapRecordIndicies = <K extends string, A>(
+  f: (k: K) => string,
+): ((r: Record<K, A>) => Record<string, A>) =>
+  flow(
+    R.collect((index: K, value) => [f(index), value] as [string, A]),
+    (pairs) =>
+      R.fromFoldableMap(S.last<A>(), A.Foldable)(pairs, ([index, value]) => [
+        index,
+        value,
+      ]),
+  )

--- a/packages/gatsby-plugin-prismic-previews/src/lib/proxyDocumentSubtree.ts
+++ b/packages/gatsby-plugin-prismic-previews/src/lib/proxyDocumentSubtree.ts
@@ -33,6 +33,7 @@ export interface ProxyDocumentSubtreeEnv {
   imagePlaceholderImgixParams: PluginOptions['imagePlaceholderImgixParams']
   nodeHelpers: NodeHelpers
   createContentDigest(input: string | UnknownRecord): string
+  transformFieldName(fieldName: string): string
 }
 
 export const proxyDocumentSubtree = (

--- a/packages/gatsby-plugin-prismic-previews/src/usePrismicPreviewBootstrap.ts
+++ b/packages/gatsby-plugin-prismic-previews/src/usePrismicPreviewBootstrap.ts
@@ -30,6 +30,7 @@ import {
 } from './types'
 import { PrismicContextActionType, PrismicContextState } from './context'
 import { usePrismicPreviewContext } from './usePrismicPreviewContext'
+import { defaultFieldTransformer } from './lib/defaultFieldTransformer'
 
 export type UsePrismicPreviewBootstrapFn = () => void
 
@@ -233,6 +234,9 @@ const previewBootstrapProgram: RTE.ReaderTaskEither<
             imagePlaceholderImgixParams:
               env.repositoryPluginOptions.imagePlaceholderImgixParams,
             htmlSerializer: env.repositoryConfig.htmlSerializer,
+            transformFieldName:
+              env.repositoryConfig.transformFieldName ??
+              defaultFieldTransformer,
           }),
         ),
       ),
@@ -253,6 +257,7 @@ const previewBootstrapProgram: RTE.ReaderTaskEither<
 export type UsePrismicPreviewBootstrapRepositoryConfig = {
   linkResolver: LinkResolver
   htmlSerializer?: HTMLSerializer
+  transformFieldName?(fieldName: string): string
 }
 
 export type UsePrismicPreviewBootstrapConfig = Record<

--- a/packages/gatsby-source-prismic/README.md
+++ b/packages/gatsby-source-prismic/README.md
@@ -161,6 +161,14 @@ module.exports = {
         //
         // See: https://user-guides.prismic.io/en/articles/790505-webhooks
         webhookSecret: process.env.PRISMIC_WEBHOOK_SECRET,
+
+        // If you field names contain characters that are not supported by
+        // GraphQL, such as dashes (e.g. "my-field"), you can provide a function
+        // that will transform a field name into one that is compatible. By
+        // default, field names with dashes will be converted to underscoes.
+        //
+        // See the "GraphQL-valid field names" section below for more details.
+        transformFieldName: (fieldName) => fieldName.replace(/-/g, '_'),
       },
     },
   ],
@@ -730,6 +738,11 @@ Note that this does not allow fields containing the following:
 - Starting with a number (e.g. `0_my_field`)
 - Dashes (e.g. `my-field`)
 - Symbols (e.g. `!@#$%^&*()`)
+
+By default, the `transformFieldName` plugin option will convert dashes (e.g.
+`my-field`) to underscores (e.g. `my_field`). If the automatic transformation
+causes a conflict, you can pass a custom function to the `transformFieldName`
+option.
 
 ## Site's `gatsby-node.js` example
 

--- a/packages/gatsby-source-prismic/README.md
+++ b/packages/gatsby-source-prismic/README.md
@@ -162,10 +162,11 @@ module.exports = {
         // See: https://user-guides.prismic.io/en/articles/790505-webhooks
         webhookSecret: process.env.PRISMIC_WEBHOOK_SECRET,
 
-        // If you field names contain characters that are not supported by
-        // GraphQL, such as dashes (e.g. "my-field"), you can provide a function
-        // that will transform a field name into one that is compatible. By
-        // default, field names with dashes will be converted to underscoes.
+        // If your custom types' field names contain characters that are not
+        // supported by GraphQL, such as dashes (e.g. "my-field"), you can
+        // provide a function that will transform a field name into one that is
+        // compatible. By default, field names with dashes will be converted to
+        // underscores.
         //
         // See the "GraphQL-valid field names" section below for more details.
         transformFieldName: (fieldName) => fieldName.replace(/-/g, '_'),

--- a/packages/gatsby-source-prismic/package.json
+++ b/packages/gatsby-source-prismic/package.json
@@ -29,6 +29,7 @@
     "prismic"
   ],
   "dependencies": {
+    "camel-case": "^4.1.2",
     "fp-ts": "^2.9.5",
     "gatsby-node-helpers": "^1.2.1",
     "gatsby-plugin-imgix": "^0.9.1-next.0",

--- a/packages/gatsby-source-prismic/src/lib/buildFieldConfigMap.ts
+++ b/packages/gatsby-source-prismic/src/lib/buildFieldConfigMap.ts
@@ -4,7 +4,7 @@ import * as R from 'fp-ts/Record'
 import * as A from 'fp-ts/Array'
 import { pipe } from 'fp-ts/function'
 
-import { mapRecordIndicies } from './mapRecordIndicies'
+import { mapRecordIndices } from './mapRecordIndices'
 import { toFieldConfig } from './toFieldConfig'
 
 import { Dependencies, PrismicSchemaField } from '../types'
@@ -34,7 +34,7 @@ export const buildFieldConfigMap = (
     RTE.chain((deps) =>
       pipe(
         fieldSchemas,
-        mapRecordIndicies(deps.pluginOptions.transformFieldName),
+        mapRecordIndices(deps.pluginOptions.transformFieldName),
         R.mapWithIndex((name, schema) =>
           toFieldConfig(pipe(path, A.append(name)), schema),
         ),

--- a/packages/gatsby-source-prismic/src/lib/buildFieldConfigMap.ts
+++ b/packages/gatsby-source-prismic/src/lib/buildFieldConfigMap.ts
@@ -4,6 +4,7 @@ import * as R from 'fp-ts/Record'
 import * as A from 'fp-ts/Array'
 import { pipe } from 'fp-ts/function'
 
+import { mapRecordIndicies } from './mapRecordIndicies'
 import { toFieldConfig } from './toFieldConfig'
 
 import { Dependencies, PrismicSchemaField } from '../types'
@@ -11,6 +12,9 @@ import { Dependencies, PrismicSchemaField } from '../types'
 /**
  * Builds a `graphql-compose`-compatible field config map by calling
  * `lib/toFieldConfig` for each field.
+ *
+ * Field names are transformed using the environment's plugin options's
+ * `transformFieldName` function.
  *
  * @param path Field path leading to `fieldSchemas`'s location.
  * @param fieldSchemas Record of Prismic custom type schema fields.
@@ -26,9 +30,15 @@ export const buildFieldConfigMap = (
   gqlc.ObjectTypeComposerFieldConfigMapDefinition<unknown, unknown>
 > =>
   pipe(
-    fieldSchemas,
-    R.mapWithIndex((name, schema) =>
-      toFieldConfig(pipe(path, A.append(name)), schema),
+    RTE.ask<Dependencies>(),
+    RTE.chain((deps) =>
+      pipe(
+        fieldSchemas,
+        mapRecordIndicies(deps.pluginOptions.transformFieldName),
+        R.mapWithIndex((name, schema) =>
+          toFieldConfig(pipe(path, A.append(name)), schema),
+        ),
+        R.sequence(RTE.ApplicativeSeq),
+      ),
     ),
-    R.sequence(RTE.ApplicativeSeq),
   )

--- a/packages/gatsby-source-prismic/src/lib/mapRecordIndices.ts
+++ b/packages/gatsby-source-prismic/src/lib/mapRecordIndices.ts
@@ -3,7 +3,7 @@ import * as A from 'fp-ts/Array'
 import * as S from 'fp-ts/Semigroup'
 import { flow } from 'fp-ts/function'
 
-export const mapRecordIndicies = <K extends string, A>(
+export const mapRecordIndices = <K extends string, A>(
   f: (k: K) => string,
 ): ((r: Record<K, A>) => Record<string, A>) =>
   flow(

--- a/packages/gatsby-source-prismic/src/lib/mapRecordIndicies.ts
+++ b/packages/gatsby-source-prismic/src/lib/mapRecordIndicies.ts
@@ -1,0 +1,16 @@
+import * as R from 'fp-ts/Record'
+import * as A from 'fp-ts/Array'
+import * as S from 'fp-ts/Semigroup'
+import { flow } from 'fp-ts/function'
+
+export const mapRecordIndicies = <K extends string, A>(
+  f: (k: K) => string,
+): ((r: Record<K, A>) => Record<string, A>) =>
+  flow(
+    R.collect((index: K, value) => [f(index), value] as [string, A]),
+    (pairs) =>
+      R.fromFoldableMap(S.last<A>(), A.Foldable)(pairs, ([index, value]) => [
+        index,
+        value,
+      ]),
+  )

--- a/packages/gatsby-source-prismic/src/plugin-options-schema.ts
+++ b/packages/gatsby-source-prismic/src/plugin-options-schema.ts
@@ -124,6 +124,9 @@ export const pluginOptionsSchema: NonNullable<
     createRemoteFileNode: Joi.function().default(
       () => gatsbyFs.createRemoteFileNode,
     ),
+    transformFieldName: Joi.function().default(() => (fieldName: string) =>
+      fieldName.replace(/-/g, '_'),
+    ),
   })
     .oxor('fetchLinks', 'graphQuery')
     .external(

--- a/packages/gatsby-source-prismic/src/types.ts
+++ b/packages/gatsby-source-prismic/src/types.ts
@@ -72,6 +72,7 @@ export interface PluginOptions extends gatsby.PluginOptions {
   webhookSecret?: string
   plugins: []
   createRemoteFileNode: typeof gatsbyFs.createRemoteFileNode
+  transformFieldName: (fieldName: string) => string
 }
 
 export type FieldConfigCreator<

--- a/packages/gatsby-source-prismic/test/__testutils__/createPluginOptions.ts
+++ b/packages/gatsby-source-prismic/test/__testutils__/createPluginOptions.ts
@@ -29,5 +29,6 @@ export const createPluginOptions = (t: ava.ExecutionContext): PluginOptions => {
     createRemoteFileNode: sinon
       .stub()
       .resolves(Promise.resolve({ id: 'remoteFileNodeId' })),
+    transformFieldName: (fieldName: string) => fieldName.replace(/-/g, '_'),
   }
 }

--- a/packages/gatsby-source-prismic/test/create-schema-customization.test.ts
+++ b/packages/gatsby-source-prismic/test/create-schema-customization.test.ts
@@ -5,7 +5,7 @@ import { createGatsbyContext } from './__testutils__/createGatsbyContext'
 import { createPluginOptions } from './__testutils__/createPluginOptions'
 import kitchenSinkSchema from './__fixtures__/kitchenSinkSchema.json'
 
-import { PrismicSchema } from '../src'
+import { PrismicSchema, PrismicSchemaTab } from '../src'
 import { createSchemaCustomization } from '../src/gatsby-node'
 
 test('creates type path nodes', async (t) => {
@@ -14,6 +14,365 @@ test('creates type path nodes', async (t) => {
 
   pluginOptions.schemas = {
     kitchen_sink: kitchenSinkSchema as PrismicSchema,
+  }
+
+  // @ts-expect-error - Partial gatsbyContext provided
+  await createSchemaCustomization(gatsbyContext, pluginOptions)
+
+  const calls = (gatsbyContext.actions.createNode as sinon.SinonStub)
+    .getCalls()
+    .filter(
+      (call) => call.firstArg.internal.type === 'PrismicPrefixTypePathType',
+    )
+    .reduce((acc: Record<string, string>, call) => {
+      acc[call.firstArg.path.join('.')] = call.firstArg.type
+
+      return acc
+    }, {})
+
+  t.deepEqual(calls, {
+    kitchen_sink: 'Document',
+    'kitchen_sink.data': 'DocumentData',
+    'kitchen_sink.data.body': 'Slices',
+    'kitchen_sink.data.body.first_option': 'Slice',
+    'kitchen_sink.data.body.first_option.items.first_option_repeat_boolean':
+      'Boolean',
+    'kitchen_sink.data.body.first_option.items.first_option_repeat_color':
+      'Color',
+    'kitchen_sink.data.body.first_option.items.first_option_repeat_content_relationship':
+      'Link',
+    'kitchen_sink.data.body.first_option.items.first_option_repeat_date':
+      'Date',
+    'kitchen_sink.data.body.first_option.items.first_option_repeat_embed':
+      'Embed',
+    'kitchen_sink.data.body.first_option.items.first_option_repeat_geopoint':
+      'GeoPoint',
+    'kitchen_sink.data.body.first_option.items.first_option_repeat_image':
+      'Image',
+    'kitchen_sink.data.body.first_option.items.first_option_repeat_key_text':
+      'Text',
+    'kitchen_sink.data.body.first_option.items.first_option_repeat_link':
+      'Link',
+    'kitchen_sink.data.body.first_option.items.first_option_repeat_link_to_media':
+      'Link',
+    'kitchen_sink.data.body.first_option.items.first_option_repeat_number':
+      'Number',
+    'kitchen_sink.data.body.first_option.items.first_option_repeat_rich_text':
+      'StructuredText',
+    'kitchen_sink.data.body.first_option.items.first_option_repeat_select':
+      'Select',
+    'kitchen_sink.data.body.first_option.items.first_option_repeat_timestamp':
+      'Timestamp',
+    'kitchen_sink.data.body.first_option.items.first_option_repeat_title':
+      'StructuredText',
+    'kitchen_sink.data.body.first_option.primary.first_option_nonrepeat_boolean':
+      'Boolean',
+    'kitchen_sink.data.body.first_option.primary.first_option_nonrepeat_color':
+      'Color',
+    'kitchen_sink.data.body.first_option.primary.first_option_nonrepeat_content_relationship':
+      'Link',
+    'kitchen_sink.data.body.first_option.primary.first_option_nonrepeat_date':
+      'Date',
+    'kitchen_sink.data.body.first_option.primary.first_option_nonrepeat_embed':
+      'Embed',
+    'kitchen_sink.data.body.first_option.primary.first_option_nonrepeat_geopoint':
+      'GeoPoint',
+    'kitchen_sink.data.body.first_option.primary.first_option_nonrepeat_image':
+      'Image',
+    'kitchen_sink.data.body.first_option.primary.first_option_nonrepeat_key_text':
+      'Text',
+    'kitchen_sink.data.body.first_option.primary.first_option_nonrepeat_link':
+      'Link',
+    'kitchen_sink.data.body.first_option.primary.first_option_nonrepeat_link_to_media':
+      'Link',
+    'kitchen_sink.data.body.first_option.primary.first_option_nonrepeat_number':
+      'Number',
+    'kitchen_sink.data.body.first_option.primary.first_option_nonrepeat_rich_text':
+      'StructuredText',
+    'kitchen_sink.data.body.first_option.primary.first_option_nonrepeat_select':
+      'Select',
+    'kitchen_sink.data.body.first_option.primary.first_option_nonrepeat_timestamp':
+      'Timestamp',
+    'kitchen_sink.data.body.first_option.primary.first_option_nonrepeat_title':
+      'StructuredText',
+    'kitchen_sink.data.body.second_option': 'Slice',
+    'kitchen_sink.data.body.second_option.items.second_option_repeat_boolean':
+      'Boolean',
+    'kitchen_sink.data.body.second_option.items.second_option_repeat_color':
+      'Color',
+    'kitchen_sink.data.body.second_option.items.second_option_repeat_content_relationship':
+      'Link',
+    'kitchen_sink.data.body.second_option.items.second_option_repeat_date':
+      'Date',
+    'kitchen_sink.data.body.second_option.items.second_option_repeat_embed':
+      'Embed',
+    'kitchen_sink.data.body.second_option.items.second_option_repeat_geopoint':
+      'GeoPoint',
+    'kitchen_sink.data.body.second_option.items.second_option_repeat_image':
+      'Image',
+    'kitchen_sink.data.body.second_option.items.second_option_repeat_key_text':
+      'Text',
+    'kitchen_sink.data.body.second_option.items.second_option_repeat_link':
+      'Link',
+    'kitchen_sink.data.body.second_option.items.second_option_repeat_link_to_media':
+      'Link',
+    'kitchen_sink.data.body.second_option.items.second_option_repeat_number':
+      'Number',
+    'kitchen_sink.data.body.second_option.items.second_option_repeat_rich_text':
+      'StructuredText',
+    'kitchen_sink.data.body.second_option.items.second_option_repeat_select':
+      'Select',
+    'kitchen_sink.data.body.second_option.items.second_option_repeat_timestamp':
+      'Timestamp',
+    'kitchen_sink.data.body.second_option.items.second_option_repeat_title':
+      'StructuredText',
+    'kitchen_sink.data.body.second_option.primary.second_option_nonrepeat_boolean':
+      'Boolean',
+    'kitchen_sink.data.body.second_option.primary.second_option_nonrepeat_color':
+      'Color',
+    'kitchen_sink.data.body.second_option.primary.second_option_nonrepeat_content_relationship':
+      'Link',
+    'kitchen_sink.data.body.second_option.primary.second_option_nonrepeat_date':
+      'Date',
+    'kitchen_sink.data.body.second_option.primary.second_option_nonrepeat_embed':
+      'Embed',
+    'kitchen_sink.data.body.second_option.primary.second_option_nonrepeat_geopoint':
+      'GeoPoint',
+    'kitchen_sink.data.body.second_option.primary.second_option_nonrepeat_image':
+      'Image',
+    'kitchen_sink.data.body.second_option.primary.second_option_nonrepeat_key_text':
+      'Text',
+    'kitchen_sink.data.body.second_option.primary.second_option_nonrepeat_link':
+      'Link',
+    'kitchen_sink.data.body.second_option.primary.second_option_nonrepeat_link_to_media':
+      'Link',
+    'kitchen_sink.data.body.second_option.primary.second_option_nonrepeat_number':
+      'Number',
+    'kitchen_sink.data.body.second_option.primary.second_option_nonrepeat_rich_text':
+      'StructuredText',
+    'kitchen_sink.data.body.second_option.primary.second_option_nonrepeat_select':
+      'Select',
+    'kitchen_sink.data.body.second_option.primary.second_option_nonrepeat_timestamp':
+      'Timestamp',
+    'kitchen_sink.data.body.second_option.primary.second_option_nonrepeat_title':
+      'StructuredText',
+    'kitchen_sink.data.boolean': 'Boolean',
+    'kitchen_sink.data.color': 'Color',
+    'kitchen_sink.data.content_relationship': 'Link',
+    'kitchen_sink.data.date': 'Date',
+    'kitchen_sink.data.embed': 'Embed',
+    'kitchen_sink.data.geopoint': 'GeoPoint',
+    'kitchen_sink.data.group': 'Group',
+    'kitchen_sink.data.group.group_boolean': 'Boolean',
+    'kitchen_sink.data.group.group_color': 'Color',
+    'kitchen_sink.data.group.group_content_relationship': 'Link',
+    'kitchen_sink.data.group.group_date': 'Date',
+    'kitchen_sink.data.group.group_embed': 'Embed',
+    'kitchen_sink.data.group.group_geopoint': 'GeoPoint',
+    'kitchen_sink.data.group.group_image': 'Image',
+    'kitchen_sink.data.group.group_key_text': 'Text',
+    'kitchen_sink.data.group.group_link': 'Link',
+    'kitchen_sink.data.group.group_link_to_media': 'Link',
+    'kitchen_sink.data.group.group_number': 'Number',
+    'kitchen_sink.data.group.group_rich_text': 'StructuredText',
+    'kitchen_sink.data.group.group_select': 'Select',
+    'kitchen_sink.data.group.group_timestamp': 'Timestamp',
+    'kitchen_sink.data.group.group_title': 'StructuredText',
+    'kitchen_sink.data.image': 'Image',
+    'kitchen_sink.data.key_text': 'Text',
+    'kitchen_sink.data.link': 'Link',
+    'kitchen_sink.data.link_to_media': 'Link',
+    'kitchen_sink.data.number': 'Number',
+    'kitchen_sink.data.rich_text': 'StructuredText',
+    'kitchen_sink.data.second_tab_body': 'Slices',
+    'kitchen_sink.data.second_tab_body.second_tab_first_option': 'Slice',
+    'kitchen_sink.data.second_tab_body.second_tab_first_option.items.second_tab_first_option_repeat_boolean':
+      'Boolean',
+    'kitchen_sink.data.second_tab_body.second_tab_first_option.items.second_tab_first_option_repeat_color':
+      'Color',
+    'kitchen_sink.data.second_tab_body.second_tab_first_option.items.second_tab_first_option_repeat_content_relationship':
+      'Link',
+    'kitchen_sink.data.second_tab_body.second_tab_first_option.items.second_tab_first_option_repeat_date':
+      'Date',
+    'kitchen_sink.data.second_tab_body.second_tab_first_option.items.second_tab_first_option_repeat_embed':
+      'Embed',
+    'kitchen_sink.data.second_tab_body.second_tab_first_option.items.second_tab_first_option_repeat_geopoint':
+      'GeoPoint',
+    'kitchen_sink.data.second_tab_body.second_tab_first_option.items.second_tab_first_option_repeat_image':
+      'Image',
+    'kitchen_sink.data.second_tab_body.second_tab_first_option.items.second_tab_first_option_repeat_key_text':
+      'Text',
+    'kitchen_sink.data.second_tab_body.second_tab_first_option.items.second_tab_first_option_repeat_link':
+      'Link',
+    'kitchen_sink.data.second_tab_body.second_tab_first_option.items.second_tab_first_option_repeat_link_to_media':
+      'Link',
+    'kitchen_sink.data.second_tab_body.second_tab_first_option.items.second_tab_first_option_repeat_number':
+      'Number',
+    'kitchen_sink.data.second_tab_body.second_tab_first_option.items.second_tab_first_option_repeat_rich_text':
+      'StructuredText',
+    'kitchen_sink.data.second_tab_body.second_tab_first_option.items.second_tab_first_option_repeat_select':
+      'Select',
+    'kitchen_sink.data.second_tab_body.second_tab_first_option.items.second_tab_first_option_repeat_timestamp':
+      'Timestamp',
+    'kitchen_sink.data.second_tab_body.second_tab_first_option.items.second_tab_first_option_repeat_title':
+      'StructuredText',
+    'kitchen_sink.data.second_tab_body.second_tab_first_option.primary.second_tab_first_option_nonrepeat_boolean':
+      'Boolean',
+    'kitchen_sink.data.second_tab_body.second_tab_first_option.primary.second_tab_first_option_nonrepeat_color':
+      'Color',
+    'kitchen_sink.data.second_tab_body.second_tab_first_option.primary.second_tab_first_option_nonrepeat_content_relationship':
+      'Link',
+    'kitchen_sink.data.second_tab_body.second_tab_first_option.primary.second_tab_first_option_nonrepeat_date':
+      'Date',
+    'kitchen_sink.data.second_tab_body.second_tab_first_option.primary.second_tab_first_option_nonrepeat_embed':
+      'Embed',
+    'kitchen_sink.data.second_tab_body.second_tab_first_option.primary.second_tab_first_option_nonrepeat_geopoint':
+      'GeoPoint',
+    'kitchen_sink.data.second_tab_body.second_tab_first_option.primary.second_tab_first_option_nonrepeat_image':
+      'Image',
+    'kitchen_sink.data.second_tab_body.second_tab_first_option.primary.second_tab_first_option_nonrepeat_key_text':
+      'Text',
+    'kitchen_sink.data.second_tab_body.second_tab_first_option.primary.second_tab_first_option_nonrepeat_link':
+      'Link',
+    'kitchen_sink.data.second_tab_body.second_tab_first_option.primary.second_tab_first_option_nonrepeat_link_to_media':
+      'Link',
+    'kitchen_sink.data.second_tab_body.second_tab_first_option.primary.second_tab_first_option_nonrepeat_number':
+      'Number',
+    'kitchen_sink.data.second_tab_body.second_tab_first_option.primary.second_tab_first_option_nonrepeat_rich_text':
+      'StructuredText',
+    'kitchen_sink.data.second_tab_body.second_tab_first_option.primary.second_tab_first_option_nonrepeat_select':
+      'Select',
+    'kitchen_sink.data.second_tab_body.second_tab_first_option.primary.second_tab_first_option_nonrepeat_timestamp':
+      'Timestamp',
+    'kitchen_sink.data.second_tab_body.second_tab_first_option.primary.second_tab_first_option_nonrepeat_title':
+      'StructuredText',
+    'kitchen_sink.data.second_tab_body.second_tab_second_option': 'Slice',
+    'kitchen_sink.data.second_tab_body.second_tab_second_option.items.second_tab_second_option_repeat_boolean':
+      'Boolean',
+    'kitchen_sink.data.second_tab_body.second_tab_second_option.items.second_tab_second_option_repeat_color':
+      'Color',
+    'kitchen_sink.data.second_tab_body.second_tab_second_option.items.second_tab_second_option_repeat_content_relationship':
+      'Link',
+    'kitchen_sink.data.second_tab_body.second_tab_second_option.items.second_tab_second_option_repeat_date':
+      'Date',
+    'kitchen_sink.data.second_tab_body.second_tab_second_option.items.second_tab_second_option_repeat_embed':
+      'Embed',
+    'kitchen_sink.data.second_tab_body.second_tab_second_option.items.second_tab_second_option_repeat_geopoint':
+      'GeoPoint',
+    'kitchen_sink.data.second_tab_body.second_tab_second_option.items.second_tab_second_option_repeat_image':
+      'Image',
+    'kitchen_sink.data.second_tab_body.second_tab_second_option.items.second_tab_second_option_repeat_key_text':
+      'Text',
+    'kitchen_sink.data.second_tab_body.second_tab_second_option.items.second_tab_second_option_repeat_link':
+      'Link',
+    'kitchen_sink.data.second_tab_body.second_tab_second_option.items.second_tab_second_option_repeat_link_to_media':
+      'Link',
+    'kitchen_sink.data.second_tab_body.second_tab_second_option.items.second_tab_second_option_repeat_number':
+      'Number',
+    'kitchen_sink.data.second_tab_body.second_tab_second_option.items.second_tab_second_option_repeat_rich_text':
+      'StructuredText',
+    'kitchen_sink.data.second_tab_body.second_tab_second_option.items.second_tab_second_option_repeat_select':
+      'Select',
+    'kitchen_sink.data.second_tab_body.second_tab_second_option.items.second_tab_second_option_repeat_timestamp':
+      'Timestamp',
+    'kitchen_sink.data.second_tab_body.second_tab_second_option.items.second_tab_second_option_repeat_title':
+      'StructuredText',
+    'kitchen_sink.data.second_tab_body.second_tab_second_option.primary.second_tab_second_option_nonrepeat_boolean':
+      'Boolean',
+    'kitchen_sink.data.second_tab_body.second_tab_second_option.primary.second_tab_second_option_nonrepeat_color':
+      'Color',
+    'kitchen_sink.data.second_tab_body.second_tab_second_option.primary.second_tab_second_option_nonrepeat_content_relationship':
+      'Link',
+    'kitchen_sink.data.second_tab_body.second_tab_second_option.primary.second_tab_second_option_nonrepeat_date':
+      'Date',
+    'kitchen_sink.data.second_tab_body.second_tab_second_option.primary.second_tab_second_option_nonrepeat_embed':
+      'Embed',
+    'kitchen_sink.data.second_tab_body.second_tab_second_option.primary.second_tab_second_option_nonrepeat_geopoint':
+      'GeoPoint',
+    'kitchen_sink.data.second_tab_body.second_tab_second_option.primary.second_tab_second_option_nonrepeat_image':
+      'Image',
+    'kitchen_sink.data.second_tab_body.second_tab_second_option.primary.second_tab_second_option_nonrepeat_key_text':
+      'Text',
+    'kitchen_sink.data.second_tab_body.second_tab_second_option.primary.second_tab_second_option_nonrepeat_link':
+      'Link',
+    'kitchen_sink.data.second_tab_body.second_tab_second_option.primary.second_tab_second_option_nonrepeat_link_to_media':
+      'Link',
+    'kitchen_sink.data.second_tab_body.second_tab_second_option.primary.second_tab_second_option_nonrepeat_number':
+      'Number',
+    'kitchen_sink.data.second_tab_body.second_tab_second_option.primary.second_tab_second_option_nonrepeat_rich_text':
+      'StructuredText',
+    'kitchen_sink.data.second_tab_body.second_tab_second_option.primary.second_tab_second_option_nonrepeat_select':
+      'Select',
+    'kitchen_sink.data.second_tab_body.second_tab_second_option.primary.second_tab_second_option_nonrepeat_timestamp':
+      'Timestamp',
+    'kitchen_sink.data.second_tab_body.second_tab_second_option.primary.second_tab_second_option_nonrepeat_title':
+      'StructuredText',
+    'kitchen_sink.data.second_tab_boolean': 'Boolean',
+    'kitchen_sink.data.second_tab_color': 'Color',
+    'kitchen_sink.data.second_tab_content_relationship': 'Link',
+    'kitchen_sink.data.second_tab_date': 'Date',
+    'kitchen_sink.data.second_tab_embed': 'Embed',
+    'kitchen_sink.data.second_tab_geopoint': 'GeoPoint',
+    'kitchen_sink.data.second_tab_group': 'Group',
+    'kitchen_sink.data.second_tab_group.second_tab_group_boolean': 'Boolean',
+    'kitchen_sink.data.second_tab_group.second_tab_group_color': 'Color',
+    'kitchen_sink.data.second_tab_group.second_tab_group_content_relationship':
+      'Link',
+    'kitchen_sink.data.second_tab_group.second_tab_group_date': 'Date',
+    'kitchen_sink.data.second_tab_group.second_tab_group_embed': 'Embed',
+    'kitchen_sink.data.second_tab_group.second_tab_group_geopoint': 'GeoPoint',
+    'kitchen_sink.data.second_tab_group.second_tab_group_image': 'Image',
+    'kitchen_sink.data.second_tab_group.second_tab_group_key_text': 'Text',
+    'kitchen_sink.data.second_tab_group.second_tab_group_link': 'Link',
+    'kitchen_sink.data.second_tab_group.second_tab_group_link_to_media': 'Link',
+    'kitchen_sink.data.second_tab_group.second_tab_group_number': 'Number',
+    'kitchen_sink.data.second_tab_group.second_tab_group_rich_text':
+      'StructuredText',
+    'kitchen_sink.data.second_tab_group.second_tab_group_select': 'Select',
+    'kitchen_sink.data.second_tab_group.second_tab_group_timestamp':
+      'Timestamp',
+    'kitchen_sink.data.second_tab_group.second_tab_group_title':
+      'StructuredText',
+    'kitchen_sink.data.second_tab_image': 'Image',
+    'kitchen_sink.data.second_tab_key_text': 'Text',
+    'kitchen_sink.data.second_tab_link': 'Link',
+    'kitchen_sink.data.second_tab_link_to_media': 'Link',
+    'kitchen_sink.data.second_tab_number': 'Number',
+    'kitchen_sink.data.second_tab_rich_text': 'StructuredText',
+    'kitchen_sink.data.second_tab_select': 'Select',
+    'kitchen_sink.data.second_tab_timestamp': 'Timestamp',
+    'kitchen_sink.data.second_tab_title': 'StructuredText',
+    'kitchen_sink.data.select': 'Select',
+    'kitchen_sink.data.timestamp': 'Timestamp',
+    'kitchen_sink.data.title': 'StructuredText',
+  })
+})
+
+test('field names with dashes are transformed with underscores by default', async (t) => {
+  const gatsbyContext = createGatsbyContext()
+  const pluginOptions = createPluginOptions(t)
+
+  const dashifiedKitchenSinkSchema = Object.keys(kitchenSinkSchema).reduce(
+    (acc: PrismicSchema, tabName) => {
+      const tab = kitchenSinkSchema[tabName as keyof typeof kitchenSinkSchema]
+
+      acc[tabName] = Object.keys(tab).reduce(
+        (tabAcc: PrismicSchemaTab, fieldName) => {
+          tabAcc[fieldName.replace(/_/g, '-')] =
+            tab[fieldName as keyof typeof tab]
+
+          return tabAcc
+        },
+        {},
+      )
+
+      return acc
+    },
+    {},
+  )
+
+  pluginOptions.schemas = {
+    kitchen_sink: dashifiedKitchenSinkSchema,
   }
 
   // @ts-expect-error - Partial gatsbyContext provided

--- a/packages/gatsby-source-prismic/test/plugin-options-schema.test.ts
+++ b/packages/gatsby-source-prismic/test/plugin-options-schema.test.ts
@@ -28,6 +28,7 @@ test('passes on valid options', async (t) => {
     typePrefix: 'string',
     webhookSecret: 'string',
     createRemoteFileNode: (): void => void 0,
+    transformFieldName: (): void => void 0,
   }
 
   server.use(


### PR DESCRIPTION
Adds ability to transform a custom type's field name before being processed. This is necessary to support invalid GraphQL field names, such as those with dashes (e.g. `my-field`).

The default value for `transformFieldName` will convert dashes to underscores (e.g. `my-field` will be converted to `my_field`). Users can override this default by providing a custom function.

**gatsby-source-prismic**
- Adds `transformFieldName` plugin options

**gatsby-plugin-prismic-previews**
- Adds `transformFieldName` config option to `withPrismicPreview()` HOC