### PR TITLE
feat: add automatic schema fetching with Custom Types API

### DIFF
--- a/packages/gatsby-source-prismic/README.md
+++ b/packages/gatsby-source-prismic/README.md
@@ -62,11 +62,25 @@ module.exports = {
         // Learn about environment variables: https://gatsby.dev/env-vars
         repositoryName: process.env.GATSBY_PRISMIC_REPOSITORY_NAME,
 
-        // An API access token to your Prismic repository. This is optional.
+        // An API access token for your Prismic repository. This is optional.
         // You can generate an access token in the "API & Security" section of
         // your repository settings. Setting a "Callback URL" is not necessary.
         // The token will be listed under "Permanent access tokens".
         accessToken: process.env.PRISMIC_ACCESS_TOKEN,
+
+        // A Custom Types API token for your Prismic repository that allows your
+        // custom type schemas to automatically be fetched. This is optional.
+        // You can provide your custom type schemas to the plugin manually using
+        // the `schemas` option.
+        //
+        // You can generate a permanent Custom Types API token in the
+        // "API & Security" section of your repository settings in the Custom
+        // Types API tab.
+        //
+        // This is a BETA feature that must be enabled on your Prismic repository.
+        //
+        // See: https://prismic.io/docs/technologies/custom-types-api
+        customTypesApiToken: process.env.PRISMIC_CUSTOM_TYPES_API_TOKEN,
 
         // If you provide a release ID, the plugin will fetch data from Prismic
         // for a specific release. A Prismic release is a way to gather a

--- a/packages/gatsby-source-prismic/README.md
+++ b/packages/gatsby-source-prismic/README.md
@@ -82,6 +82,16 @@ module.exports = {
         // See: https://prismic.io/docs/technologies/custom-types-api
         customTypesApiToken: process.env.PRISMIC_CUSTOM_TYPES_API_TOKEN,
 
+        // Provide an object of Prismic custom type JSON schemas to load into
+        // Gatsby. This is required only if you do not provide a value to
+        // customTypesApiToken.
+        //
+        // You may also provide schemas here to override the schemas pulled
+        // automatically from the API.
+        schemas: {
+          // Your custom type JSON schemas.
+        },
+
         // If you provide a release ID, the plugin will fetch data from Prismic
         // for a specific release. A Prismic release is a way to gather a
         // collection of changes for a future version of your website. Note that
@@ -90,12 +100,6 @@ module.exports = {
         //
         // See: https://user-guides.prismic.io/en/articles/778358-what-is-a-release
         releaseID: process.env.PRISMIC_RELEASE_ID,
-
-        // Provide an object of Prismic custom type JSON schemas to load into
-        // Gatsby. This is required.
-        schemas: {
-          // Your custom type JSON schemas.
-        },
 
         // Set a Link Resolver function used to process links in your content.
         // Fields with Rich Text formatting or links to internal content use this
@@ -192,12 +196,22 @@ module.exports = {
 
 ## Providing JSON schemas
 
-In order for Gatsby to know about your Prismic custom types, you must provide
-the full JSON schema of each custom type. This is done via the plugin's
-`schemas` option in `gatsby-config.js`.
+In order for Gatsby to know about your Prismic custom types and provide a full
+GraphQL experience, the JSON schemas of each custom type must be provided to
+Gatsby.
 
-The recommended approach is to create a `schemas` directory in your project and
-import them into your `gatsby-config.js` file.
+> **Note**: A new automated process for fetching your repository's schemas is
+> currently in Beta. You can request that the Custom Types API feature be
+> enabled on your repository which will allow you to provide a
+> `customTypesApiToken` to your plugin options (see the
+> [How to use](#how-to-use) section for details).
+>
+> See the
+> [Custom Types API documentation](https://prismic.io/docs/technologies/custom-types-api)
+> for more details.
+
+The recommended approach to provide your schemas to create a `schemas` directory
+in your project and import them into your `gatsby-config.js` file.
 
 ```javascript
 // In your gatsby-config.js

--- a/packages/gatsby-source-prismic/src/constants.ts
+++ b/packages/gatsby-source-prismic/src/constants.ts
@@ -13,6 +13,15 @@ export const GLOBAL_TYPE_PREFIX = 'Prismic'
 export const PRISMIC_API_NON_DATA_FIELDS = ['uid']
 
 /**
+ * Endpoint used to fetch custom type JSON schemas from Prismic's Custom Type
+ * API.
+ *
+ * @see https://prismic.io/docs/technologies/custom-types-api
+ */
+export const PRISMIC_CUSTOM_TYPES_API_ENDPOINT =
+  'https://customtypes.prismic.io/customtypes'
+
+/**
  * Default Imgix URL parameters for `gatsby-plugin-image` fields.
  *
  * These defaults provide a good balance between image quality and filesize.

--- a/packages/gatsby-source-prismic/src/plugin-options-schema.ts
+++ b/packages/gatsby-source-prismic/src/plugin-options-schema.ts
@@ -70,8 +70,13 @@ const externalCustomTypeFetchingProgram = (
             }).json<PrismicCustomTypeApiResponse>(),
           () =>
             new Joi.ValidationError(
-              'The Custom Type API could not be accessed. Please check that the customTypeApiToken provided is valid.',
-              [],
+              'Failed Custom Type API Request',
+              [
+                {
+                  message:
+                    'The Custom Type API could not be accessed. Please check that the customTypeApiToken provided is valid.',
+                },
+              ],
               scope.pluginOptions,
             ),
         ),
@@ -120,8 +125,8 @@ const externalValidationProgram = (
           () => got(scope.repositoryURL).json<prismic.Response.Repository>(),
           () =>
             new Joi.ValidationError(
-              COULD_NOT_ACCESS_MSG,
-              [],
+              'Failed repository request',
+              [{ message: COULD_NOT_ACCESS_MSG }],
               scope.repositoryURL,
             ),
         ),

--- a/packages/gatsby-source-prismic/src/plugin-options-schema.ts
+++ b/packages/gatsby-source-prismic/src/plugin-options-schema.ts
@@ -205,7 +205,7 @@ export const pluginOptionsSchema: NonNullable<
           externalCustomTypeFetchingProgram(Joi)({ pluginOptions }),
           TE.fold(
             (error) =>
-              // Non-ValidationErrors are used to as control flow, so we can
+              // Non-ValidationErrors are used for flow control, so we can
               // ignore the error if it isn't specifically one made for Joi.
               error instanceof Joi.ValidationError
                 ? throwError(error)

--- a/packages/gatsby-source-prismic/src/plugin-options-schema.ts
+++ b/packages/gatsby-source-prismic/src/plugin-options-schema.ts
@@ -49,16 +49,16 @@ const externalCustomTypeFetchingProgram = (
   pipe(
     RTE.ask<Pick<Dependencies, 'pluginOptions'>>(),
     RTE.filterOrElse(
-      (deps) => Boolean(deps.pluginOptions.customTypeApiToken),
+      (deps) => Boolean(deps.pluginOptions.customTypesApiToken),
       () =>
         new Error(
-          'No customTypeApiToken provided (skipping Custom Types API fetching)',
+          'No customTypesApiToken provided (skipping Custom Types API fetching)',
         ),
     ),
     RTE.bind('headers', (scope) =>
       RTE.of({
         repository: scope.pluginOptions.repositoryName,
-        Authorization: `Bearer ${scope.pluginOptions.customTypeApiToken}`,
+        Authorization: `Bearer ${scope.pluginOptions.customTypesApiToken}`,
       }),
     ),
     RTE.bindW('response', (scope) =>
@@ -74,7 +74,7 @@ const externalCustomTypeFetchingProgram = (
               [
                 {
                   message:
-                    'The Custom Type API could not be accessed. Please check that the customTypeApiToken provided is valid.',
+                    'The Custom Type API could not be accessed. Please check that the customTypesApiToken provided is valid.',
                 },
               ],
               scope.pluginOptions,
@@ -173,7 +173,7 @@ export const pluginOptionsSchema: NonNullable<
   const schema = Joi.object({
     repositoryName: Joi.string().required(),
     accessToken: Joi.string(),
-    customTypeApiToken: Joi.string(),
+    customTypesApiToken: Joi.string(),
     apiEndpoint: Joi.string().default((parent) =>
       prismic.defaultEndpoint(parent.repositoryName),
     ),
@@ -197,7 +197,7 @@ export const pluginOptionsSchema: NonNullable<
       fieldName.replace(/-/g, '_'),
     ),
   })
-    .or('schemas', 'customTypeApiToken')
+    .or('schemas', 'customTypesApiToken')
     .oxor('fetchLinks', 'graphQuery')
     .external(
       async (pluginOptions: PluginOptions) =>

--- a/packages/gatsby-source-prismic/src/plugin-options-schema.ts
+++ b/packages/gatsby-source-prismic/src/plugin-options-schema.ts
@@ -6,7 +6,8 @@ import * as TE from 'fp-ts/TaskEither'
 import * as T from 'fp-ts/Task'
 import * as A from 'fp-ts/Array'
 import * as R from 'fp-ts/Record'
-import * as s from 'fp-ts/string'
+import * as struct from 'fp-ts/struct'
+import * as string from 'fp-ts/string'
 import { constVoid, pipe } from 'fp-ts/function'
 import got from 'got'
 
@@ -20,8 +21,73 @@ import {
   MISSING_SCHEMAS_MSG,
   MISSING_SCHEMA_MSG,
   COULD_NOT_ACCESS_MSG,
+  PRISMIC_CUSTOM_TYPES_API_ENDPOINT,
 } from './constants'
-import { Dependencies, JoiValidationError, PluginOptions } from './types'
+import {
+  Dependencies,
+  JoiValidationError,
+  PluginOptions,
+  PrismicCustomTypeApiResponse,
+  PrismicSchema,
+} from './types'
+
+const getSchemasFromCustomTypeApiResponse = (
+  response: PrismicCustomTypeApiResponse,
+) =>
+  R.fromFoldableMap(
+    struct.getAssignSemigroup<PrismicSchema>(),
+    A.Foldable,
+  )(response, (item) => [item.id, item.json])
+
+const externalCustomTypeFetchingProgram = (
+  Joi: gatsby.PluginOptionsSchemaArgs['Joi'],
+): RTE.ReaderTaskEither<
+  Pick<Dependencies, 'pluginOptions'>,
+  Error,
+  PluginOptions
+> =>
+  pipe(
+    RTE.ask<Pick<Dependencies, 'pluginOptions'>>(),
+    RTE.filterOrElse(
+      (deps) => Boolean(deps.pluginOptions.customTypeApiToken),
+      () =>
+        new Error(
+          'No customTypeApiToken provided (skipping Custom Types API fetching)',
+        ),
+    ),
+    RTE.bind('headers', (scope) =>
+      RTE.of({
+        repository: scope.pluginOptions.repositoryName,
+        Authorization: `Bearer ${scope.pluginOptions.customTypeApiToken}`,
+      }),
+    ),
+    RTE.bindW('response', (scope) =>
+      RTE.fromTaskEither(
+        TE.tryCatch(
+          () =>
+            got(PRISMIC_CUSTOM_TYPES_API_ENDPOINT, {
+              headers: scope.headers,
+            }).json<PrismicCustomTypeApiResponse>(),
+          () =>
+            new Joi.ValidationError(
+              'The Custom Type API could not be accessed. Please check that the customTypeApiToken provided is valid.',
+              [],
+              scope.pluginOptions,
+            ),
+        ),
+      ),
+    ),
+    RTE.bind('fetchedSchemas', (scope) =>
+      RTE.of(getSchemasFromCustomTypeApiResponse(scope.response)),
+    ),
+    RTE.map((scope) => ({
+      ...scope.pluginOptions,
+      schemas: {
+        ...scope.fetchedSchemas,
+        ...scope.pluginOptions.schemas,
+      },
+    })),
+  )
 
 /**
  * To be executed during the `external` phase of `pluginOptionsSchema`.
@@ -51,10 +117,7 @@ const externalValidationProgram = (
     RTE.bind('repository', (scope) =>
       RTE.fromTaskEither(
         TE.tryCatch(
-          () =>
-            got(
-              scope.repositoryURL,
-            ).json() as Promise<prismic.Response.Repository>,
+          () => got(scope.repositoryURL).json<prismic.Response.Repository>(),
           () =>
             new Joi.ValidationError(
               COULD_NOT_ACCESS_MSG,
@@ -71,7 +134,7 @@ const externalValidationProgram = (
       pipe(
         scope.repository.types,
         R.keys,
-        A.difference(s.Eq)(scope.schemaTypes),
+        A.difference(string.Eq)(scope.schemaTypes),
         (missingSchemas) => RTE.right(missingSchemas),
       ),
     ),
@@ -105,6 +168,7 @@ export const pluginOptionsSchema: NonNullable<
   const schema = Joi.object({
     repositoryName: Joi.string().required(),
     accessToken: Joi.string(),
+    customTypeApiToken: Joi.string(),
     apiEndpoint: Joi.string().default((parent) =>
       prismic.defaultEndpoint(parent.repositoryName),
     ),
@@ -114,7 +178,7 @@ export const pluginOptionsSchema: NonNullable<
     lang: Joi.string().default(DEFAULT_LANG),
     linkResolver: Joi.function(),
     htmlSerializer: Joi.function(),
-    schemas: Joi.object().required(),
+    schemas: Joi.object(),
     imageImgixParams: Joi.object().default(DEFAULT_IMGIX_PARAMS),
     imagePlaceholderImgixParams: Joi.object().default(
       DEFAULT_PLACEHOLDER_IMGIX_PARAMS,
@@ -128,7 +192,23 @@ export const pluginOptionsSchema: NonNullable<
       fieldName.replace(/-/g, '_'),
     ),
   })
+    .or('schemas', 'customTypeApiToken')
     .oxor('fetchLinks', 'graphQuery')
+    .external(
+      async (pluginOptions: PluginOptions) =>
+        await pipe(
+          externalCustomTypeFetchingProgram(Joi)({ pluginOptions }),
+          TE.fold(
+            (error) =>
+              // Non-ValidationErrors are used to as control flow, so we can
+              // ignore the error if it isn't specifically one made for Joi.
+              error instanceof Joi.ValidationError
+                ? throwError(error)
+                : T.of(void 0),
+            (p) => T.of(p),
+          ),
+        )(),
+    )
     .external(
       async (pluginOptions: PluginOptions) =>
         await pipe(

--- a/packages/gatsby-source-prismic/src/types.ts
+++ b/packages/gatsby-source-prismic/src/types.ts
@@ -58,7 +58,7 @@ export interface Dependencies {
 export interface PluginOptions extends gatsby.PluginOptions {
   repositoryName: string
   accessToken?: string
-  customTypeApiToken?: string
+  customTypesApiToken?: string
   apiEndpoint: string
   releaseID?: string
   graphQuery?: string

--- a/packages/gatsby-source-prismic/src/types.ts
+++ b/packages/gatsby-source-prismic/src/types.ts
@@ -58,6 +58,7 @@ export interface Dependencies {
 export interface PluginOptions extends gatsby.PluginOptions {
   repositoryName: string
   accessToken?: string
+  customTypeApiToken?: string
   apiEndpoint: string
   releaseID?: string
   graphQuery?: string
@@ -282,4 +283,13 @@ interface PrismicWebhookExperimentVariation {
   id: string
   ref: string
   label: string
+}
+
+export type PrismicCustomTypeApiResponse = PrismicCustomTypeApiCustomType[]
+
+export interface PrismicCustomTypeApiCustomType {
+  id: string
+  label: string
+  repeatable: boolean
+  json: PrismicSchema
 }

--- a/packages/gatsby-source-prismic/test/__testutils__/createAPIRepositoryMockedRequest.ts
+++ b/packages/gatsby-source-prismic/test/__testutils__/createAPIRepositoryMockedRequest.ts
@@ -1,5 +1,6 @@
 import * as msw from 'msw'
 import * as prismic from 'ts-prismic'
+
 import { PluginOptions } from '../../src'
 
 const DEFAULT_RESPONSE: prismic.Response.Repository = {

--- a/packages/gatsby-source-prismic/test/__testutils__/createCustomTypesAPICustomType.ts
+++ b/packages/gatsby-source-prismic/test/__testutils__/createCustomTypesAPICustomType.ts
@@ -1,0 +1,24 @@
+import * as crypto from 'crypto'
+
+import { PrismicCustomTypeApiCustomType, PrismicFieldType } from '../../src'
+
+export const createCustomTypesAPICustomType = (
+  customType?: Partial<PrismicCustomTypeApiCustomType>,
+): PrismicCustomTypeApiCustomType => {
+  const id = crypto
+    .createHash('md5')
+    .update(Math.random().toString())
+    .digest('hex')
+
+  return {
+    id: id,
+    label: id,
+    repeatable: true,
+    json: {
+      Main: {
+        foo: { type: PrismicFieldType.Text, config: {} },
+      },
+    },
+    ...customType,
+  }
+}

--- a/packages/gatsby-source-prismic/test/__testutils__/createCustomTypesAPIMockedRequest.ts
+++ b/packages/gatsby-source-prismic/test/__testutils__/createCustomTypesAPIMockedRequest.ts
@@ -3,7 +3,7 @@ import * as msw from 'msw'
 import { PluginOptions, PrismicCustomTypeApiResponse } from '../../src'
 
 export const createCustomTypesAPIMockedRequest = (
-  pluginOptions: Pick<PluginOptions, 'repositoryName' | 'customTypeApiToken'>,
+  pluginOptions: Pick<PluginOptions, 'repositoryName' | 'customTypesApiToken'>,
   response: PrismicCustomTypeApiResponse,
 ): msw.RestHandler =>
   msw.rest.get(
@@ -14,7 +14,7 @@ export const createCustomTypesAPIMockedRequest = (
 
       if (
         repositoryHeader === pluginOptions.repositoryName &&
-        authorizationHeader === `Bearer ${pluginOptions.customTypeApiToken}`
+        authorizationHeader === `Bearer ${pluginOptions.customTypesApiToken}`
       ) {
         return res(ctx.json(response))
       } else {

--- a/packages/gatsby-source-prismic/test/__testutils__/createCustomTypesAPIMockedRequest.ts
+++ b/packages/gatsby-source-prismic/test/__testutils__/createCustomTypesAPIMockedRequest.ts
@@ -1,0 +1,24 @@
+import * as msw from 'msw'
+
+import { PluginOptions, PrismicCustomTypeApiResponse } from '../../src'
+
+export const createCustomTypesAPIMockedRequest = (
+  pluginOptions: Pick<PluginOptions, 'repositoryName' | 'customTypeApiToken'>,
+  response: PrismicCustomTypeApiResponse,
+): msw.RestHandler =>
+  msw.rest.get(
+    'https://customtypes.prismic.io/customtypes',
+    (req, res, ctx) => {
+      const repositoryHeader = req.headers.get('repository')
+      const authorizationHeader = req.headers.get('Authorization')
+
+      if (
+        repositoryHeader === pluginOptions.repositoryName &&
+        authorizationHeader === `Bearer ${pluginOptions.customTypeApiToken}`
+      ) {
+        return res(ctx.json(response))
+      } else {
+        return res(ctx.status(401))
+      }
+    },
+  )

--- a/packages/gatsby-source-prismic/test/__testutils__/createPluginOptions.ts
+++ b/packages/gatsby-source-prismic/test/__testutils__/createPluginOptions.ts
@@ -16,7 +16,7 @@ export const createPluginOptions = (t: ava.ExecutionContext): PluginOptions => {
   return {
     repositoryName,
     accessToken: 'accessToken',
-    customTypeApiToken: 'customTypeApiToken',
+    customTypesApiToken: 'customTypesApiToken',
     apiEndpoint: prismic.defaultEndpoint(repositoryName),
     typePrefix: 'prefix',
     schemas: {},

--- a/packages/gatsby-source-prismic/test/__testutils__/createPluginOptions.ts
+++ b/packages/gatsby-source-prismic/test/__testutils__/createPluginOptions.ts
@@ -16,6 +16,7 @@ export const createPluginOptions = (t: ava.ExecutionContext): PluginOptions => {
   return {
     repositoryName,
     accessToken: 'accessToken',
+    customTypeApiToken: 'customTypeApiToken',
     apiEndpoint: prismic.defaultEndpoint(repositoryName),
     typePrefix: 'prefix',
     schemas: {},

--- a/packages/gatsby-source-prismic/test/plugin-options-schema.test.ts
+++ b/packages/gatsby-source-prismic/test/plugin-options-schema.test.ts
@@ -2,20 +2,29 @@ import test from 'ava'
 import * as msw from 'msw'
 import * as mswn from 'msw/node'
 import * as prismic from 'ts-prismic'
-import { testPluginOptionsSchema } from 'gatsby-plugin-utils'
+import {
+  testPluginOptionsSchema,
+  Joi,
+  validateOptionsSchema,
+} from 'gatsby-plugin-utils'
 
 import kitchenSinkSchemaFixture from './__fixtures__/kitchenSinkSchema.json'
+import { createCustomTypesAPICustomType } from './__testutils__/createCustomTypesAPICustomType'
+import { createCustomTypesAPIMockedRequest } from './__testutils__/createCustomTypesAPIMockedRequest'
 
+import { PluginOptions, PrismicCustomTypeApiResponse } from '../src'
 import { pluginOptionsSchema } from '../src/plugin-options-schema'
 
 const server = mswn.setupServer()
 test.before(() => server.listen({ onUnhandledRequest: 'error' }))
+test.afterEach(() => server.resetHandlers())
 test.after(() => server.close())
 
-test('passes on valid options', async (t) => {
+test.serial('passes on valid options', async (t) => {
   const pluginOptions = {
     repositoryName: 'string',
     accessToken: 'string',
+    customTypeApiToken: 'string',
     apiEndpoint: 'https://example.com',
     releaseID: 'string',
     graphQuery: 'string',
@@ -44,6 +53,8 @@ test('passes on valid options', async (t) => {
     ),
   )
 
+  server.use(createCustomTypesAPIMockedRequest(pluginOptions, []))
+
   const res = await testPluginOptionsSchema(pluginOptionsSchema, pluginOptions)
 
   t.true(res.isValid)
@@ -57,7 +68,7 @@ test('fails on missing options', async (t) => {
   t.false(res.isValid)
   t.deepEqual(res.errors, [
     '"repositoryName" is required',
-    '"schemas" is required',
+    '"value" must contain at least one of [schemas, customTypeApiToken]',
   ])
 })
 
@@ -65,6 +76,7 @@ test('fails on invalid options', async (t) => {
   const pluginOptions = {
     repositoryName: Symbol(),
     accessToken: Symbol(),
+    customTypeApiToken: Symbol(),
     apiEndpoint: Symbol(),
     releaseID: Symbol(),
     graphQuery: Symbol(),
@@ -84,6 +96,7 @@ test('fails on invalid options', async (t) => {
   t.deepEqual(res.errors, [
     '"repositoryName" must be a string',
     '"accessToken" must be a string',
+    '"customTypeApiToken" must be a string',
     '"apiEndpoint" must be a string',
     '"releaseID" must be a string',
     '"graphQuery" must be a string',
@@ -114,7 +127,7 @@ test('allows only one of qraphQuery or fetchLinks', async (t) => {
   ])
 })
 
-test('checks that all schemas are provided', async (t) => {
+test.serial('checks that all schemas are provided', async (t) => {
   const pluginOptions = {
     repositoryName: 'qwerty',
     schemas: { page: kitchenSinkSchemaFixture },
@@ -131,9 +144,120 @@ test('checks that all schemas are provided', async (t) => {
     ),
   )
 
+  server.use(createCustomTypesAPIMockedRequest(pluginOptions, []))
+
   const res = await testPluginOptionsSchema(pluginOptionsSchema, pluginOptions)
 
   t.false(res.isValid)
   t.true(res.errors.length === 1)
   t.true(/blogPost/.test(res.errors[0]))
 })
+
+test.serial(
+  'populates schemas if customTypeApiToken is provided',
+  async (t) => {
+    const pluginOptions = {
+      repositoryName: 'qwerty',
+      customTypeApiToken: 'customTypeApiToken',
+    }
+    const apiEndpoint = prismic.defaultEndpoint(pluginOptions.repositoryName)
+
+    const customType1 = createCustomTypesAPICustomType()
+    const customType2 = createCustomTypesAPICustomType()
+    const customTypesResponse: PrismicCustomTypeApiResponse = [
+      customType1,
+      customType2,
+    ]
+
+    server.use(
+      msw.rest.get(apiEndpoint, (_req, res, ctx) =>
+        res(
+          ctx.json({
+            types: {
+              [customType1.id]: customType1.label,
+              [customType2.id]: customType2.label,
+            },
+          }),
+        ),
+      ),
+    )
+
+    server.use(
+      createCustomTypesAPIMockedRequest(pluginOptions, customTypesResponse),
+    )
+
+    const schema = pluginOptionsSchema({ Joi })
+    const res = (await validateOptionsSchema(
+      schema,
+      pluginOptions,
+    )) as PluginOptions
+
+    t.deepEqual(res.schemas, {
+      [customType1.id]: customType1.json,
+      [customType2.id]: customType2.json,
+    })
+  },
+)
+
+test.serial(
+  'merges schemas if customTypeApiToken and schemas are provided',
+  async (t) => {
+    const customTypeNotInAPI = createCustomTypesAPICustomType()
+    const customTypeInAPI1 = createCustomTypesAPICustomType()
+    const customTypeInAPI2 = createCustomTypesAPICustomType()
+    const customTypesResponse: PrismicCustomTypeApiResponse = [
+      customTypeInAPI1,
+      customTypeInAPI2,
+    ]
+
+    const pluginOptions = {
+      repositoryName: 'qwerty',
+      customTypeApiToken: 'customTypeApiToken',
+      schemas: {
+        [customTypeNotInAPI.id]: customTypeNotInAPI.json,
+        // Note that we are going to replace customTypeInAPI2 with
+        // customTypeNotInAPI, in which customTypeInAPI2 is part of the API
+        // response. The test at the end checks for this.
+        [customTypeInAPI2.id]: customTypeNotInAPI.json,
+      },
+    }
+    const apiEndpoint = prismic.defaultEndpoint(pluginOptions.repositoryName)
+
+    server.use(
+      msw.rest.get(apiEndpoint, (_req, res, ctx) =>
+        res(
+          ctx.json({
+            types: {
+              [customTypesResponse[0].id]: customTypesResponse[0].label,
+              [customTypesResponse[1].id]: customTypesResponse[1].label,
+            },
+          }),
+        ),
+      ),
+    )
+
+    server.use(
+      createCustomTypesAPIMockedRequest(pluginOptions, customTypesResponse),
+    )
+
+    const schema = pluginOptionsSchema({ Joi })
+    const res = (await validateOptionsSchema(
+      schema,
+      pluginOptions,
+    )) as PluginOptions
+
+    t.deepEqual(res.schemas, {
+      // We are testing that a schema provided in the plugin options, but not
+      // provided by the API, can be provided explicitly.
+      [customTypeNotInAPI.id]: customTypeNotInAPI.json,
+
+      // This custom type was not provided in the plugin options, but is provided
+      // by the API.
+      [customTypeInAPI1.id]: customTypeInAPI1.json,
+
+      // We are testing that a schema provided by the API can be overridden by
+      // one provided in plugin options.
+      [customTypeInAPI2.id]: customTypeNotInAPI.json,
+    })
+  },
+)

--- a/packages/gatsby-source-prismic/test/plugin-options-schema.test.ts
+++ b/packages/gatsby-source-prismic/test/plugin-options-schema.test.ts
@@ -61,7 +61,7 @@ test.serial('passes on valid options', async (t) => {
   t.deepEqual(res.errors, [])
 })
 
-test('fails on missing options', async (t) => {
+test.serial('fails on missing options', async (t) => {
   const pluginOptions = {}
   const res = await testPluginOptionsSchema(pluginOptionsSchema, pluginOptions)
 
@@ -72,7 +72,7 @@ test('fails on missing options', async (t) => {
   ])
 })
 
-test('fails on invalid options', async (t) => {
+test.serial('fails on invalid options', async (t) => {
   const pluginOptions = {
     repositoryName: Symbol(),
     accessToken: Symbol(),
@@ -112,7 +112,29 @@ test('fails on invalid options', async (t) => {
   ])
 })
 
-test('allows only one of qraphQuery or fetchLinks', async (t) => {
+test.serial('fails on invalid customTypeApiToken', async (t) => {
+  const pluginOptions = {
+    repositoryName: 'qwerty',
+    customTypeApiToken: 'customTypeApiToken',
+  }
+
+  // Intentionally making a failed 401 response.
+  server.use(
+    msw.rest.get(
+      'https://customtypes.prismic.io/customtypes',
+      (_req, res, ctx) => res(ctx.status(401)),
+    ),
+  )
+
+  const res = await testPluginOptionsSchema(pluginOptionsSchema, pluginOptions)
+
+  t.false(res.isValid)
+  t.deepEqual(res.errors, [
+    'The Custom Type API could not be accessed. Please check that the customTypeApiToken provided is valid.',
+  ])
+})
+
+test.serial('allows only one of qraphQuery or fetchLinks', async (t) => {
   const pluginOptions = {
     repositoryName: 'qwerty',
     schemas: { page: kitchenSinkSchemaFixture },

--- a/packages/gatsby-source-prismic/test/plugin-options-schema.test.ts
+++ b/packages/gatsby-source-prismic/test/plugin-options-schema.test.ts
@@ -24,7 +24,7 @@ test.serial('passes on valid options', async (t) => {
   const pluginOptions = {
     repositoryName: 'string',
     accessToken: 'string',
-    customTypeApiToken: 'string',
+    customTypesApiToken: 'string',
     apiEndpoint: 'https://example.com',
     releaseID: 'string',
     graphQuery: 'string',
@@ -68,7 +68,7 @@ test.serial('fails on missing options', async (t) => {
   t.false(res.isValid)
   t.deepEqual(res.errors, [
     '"repositoryName" is required',
-    '"value" must contain at least one of [schemas, customTypeApiToken]',
+    '"value" must contain at least one of [schemas, customTypesApiToken]',
   ])
 })
 
@@ -76,7 +76,7 @@ test.serial('fails on invalid options', async (t) => {
   const pluginOptions = {
     repositoryName: Symbol(),
     accessToken: Symbol(),
-    customTypeApiToken: Symbol(),
+    customTypesApiToken: Symbol(),
     apiEndpoint: Symbol(),
     releaseID: Symbol(),
     graphQuery: Symbol(),
@@ -96,7 +96,7 @@ test.serial('fails on invalid options', async (t) => {
   t.deepEqual(res.errors, [
     '"repositoryName" must be a string',
     '"accessToken" must be a string',
-    '"customTypeApiToken" must be a string',
+    '"customTypesApiToken" must be a string',
     '"apiEndpoint" must be a string',
     '"releaseID" must be a string',
     '"graphQuery" must be a string',
@@ -112,10 +112,10 @@ test.serial('fails on invalid options', async (t) => {
   ])
 })
 
-test.serial('fails on invalid customTypeApiToken', async (t) => {
+test.serial('fails on invalid customTypesApiToken', async (t) => {
   const pluginOptions = {
     repositoryName: 'qwerty',
-    customTypeApiToken: 'customTypeApiToken',
+    customTypesApiToken: 'customTypesApiToken',
   }
 
   // Intentionally making a failed 401 response.
@@ -130,7 +130,7 @@ test.serial('fails on invalid customTypeApiToken', async (t) => {
 
   t.false(res.isValid)
   t.deepEqual(res.errors, [
-    'The Custom Type API could not be accessed. Please check that the customTypeApiToken provided is valid.',
+    'The Custom Type API could not be accessed. Please check that the customTypesApiToken provided is valid.',
   ])
 })
 
@@ -176,11 +176,11 @@ test.serial('checks that all schemas are provided', async (t) => {
 })
 
 test.serial(
-  'populates schemas if customTypeApiToken is provided',
+  'populates schemas if customTypesApiToken is provided',
   async (t) => {
     const pluginOptions = {
       repositoryName: 'qwerty',
-      customTypeApiToken: 'customTypeApiToken',
+      customTypesApiToken: 'customTypesApiToken',
     }
     const apiEndpoint = prismic.defaultEndpoint(pluginOptions.repositoryName)
 
@@ -222,7 +222,7 @@ test.serial(
 )
 
 test.serial(
-  'merges schemas if customTypeApiToken and schemas are provided',
+  'merges schemas if customTypesApiToken and schemas are provided',
   async (t) => {
     const customTypeNotInAPI = createCustomTypesAPICustomType()
     const customTypeInAPI1 = createCustomTypesAPICustomType()
@@ -234,7 +234,7 @@ test.serial(
 
     const pluginOptions = {
       repositoryName: 'qwerty',
-      customTypeApiToken: 'customTypeApiToken',
+      customTypesApiToken: 'customTypesApiToken',
       schemas: {
         [customTypeNotInAPI.id]: customTypeNotInAPI.json,
         // Note that we are going to replace customTypeInAPI2 with

--- a/packages/gatsby-source-prismic/test/source-nodes.test.ts
+++ b/packages/gatsby-source-prismic/test/source-nodes.test.ts
@@ -195,7 +195,7 @@ test('embed fields are normalized to inferred nodes', async (t) => {
   )
 })
 
-test.only('integration fields are normalized to inferred nodes', async (t) => {
+test('integration fields are normalized to inferred nodes', async (t) => {
   const gatsbyContext = createGatsbyContext()
   const pluginOptions = createPluginOptions(t)
   const docWithIntegrationId = createPrismicAPIDocument({

--- a/packages/test-site/.env.secret.example
+++ b/packages/test-site/.env.secret.example
@@ -1,0 +1,1 @@
+PRISMIC_CUSTOM_TYPES_API_TOKEN=prismic_custom_types_api_token

--- a/packages/test-site/.gitignore
+++ b/packages/test-site/.gitignore
@@ -1,2 +1,3 @@
 /.cache/
 /public/
+.env.secret

--- a/packages/test-site/gatsby-config.js
+++ b/packages/test-site/gatsby-config.js
@@ -2,6 +2,7 @@ const path = require('path')
 const dotenv = require('dotenv')
 
 dotenv.config()
+dotenv.config({ path: '.env.secret' })
 
 module.exports = {
   plugins: [
@@ -10,6 +11,7 @@ module.exports = {
       options: {
         repositoryName: process.env.GATSBY_PRISMIC_REPOSITORY_NAME,
         accessToken: process.env.PRISMIC_ACCESS_TOKEN,
+        customTypesApiToken: process.env.PRISMIC_CUSTOM_TYPES_API_TOKEN,
         typePrefix: 'prefix',
         schemas: {
           kitchen_sink: require('./schemas/kitchen_sink.json'),


### PR DESCRIPTION
Related Issue: #349
Related PR: #316 

Adds a `customTypesApiToken` plugin option to `gatsby-source-prismic` that enables automatic custom type schema fetching.

This can replace the practice of users needing to manually copy and paste custom type JSON schemas into their project and passing them via the `schemas` option.

This feature relies on the **BETA** Custom Types API that must be enabled on a per-repository basis.

**See**: https://prismic.io/docs/technologies/custom-types-api

If the schemas pulled from the API need to be overridden, they can still be provided via the `schemas` option. Schemas pulled from the API and provided manually in `gatsby-node.js` will be merged, with priority given to the manual schemas. This should help in the future with Slice Machine integration and local custom type JSON files.

(cc @MarcMcIntosh)