### PR TITLE
feat: use @imgix/gatsby field helpers and support new gatsby-plugin-image v3 API

### DIFF
--- a/packages/gatsby-source-prismic/package.json
+++ b/packages/gatsby-source-prismic/package.json
@@ -29,7 +29,7 @@
     "prismic"
   ],
   "dependencies": {
-    "@imgix/gatsby": "^1.6.0-rc.1",
+    "@imgix/gatsby": "^1.6.0-rc.3",
     "camel-case": "^4.1.2",
     "fp-ts": "^2.9.5",
     "gatsby-node-helpers": "^1.2.1",

--- a/packages/gatsby-source-prismic/package.json
+++ b/packages/gatsby-source-prismic/package.json
@@ -29,7 +29,7 @@
     "prismic"
   ],
   "dependencies": {
-    "@imgix/gatsby": "^1.6.0-rc.3",
+    "@imgix/gatsby": "^1.6.0",
     "camel-case": "^4.1.2",
     "fp-ts": "^2.9.5",
     "gatsby-node-helpers": "^1.2.1",

--- a/packages/gatsby-source-prismic/package.json
+++ b/packages/gatsby-source-prismic/package.json
@@ -29,6 +29,7 @@
     "prismic"
   ],
   "dependencies": {
+    "@imgix/gatsby": "^1.5.0",
     "camel-case": "^4.1.2",
     "fp-ts": "^2.9.5",
     "gatsby-node-helpers": "^1.2.1",

--- a/packages/gatsby-source-prismic/package.json
+++ b/packages/gatsby-source-prismic/package.json
@@ -29,7 +29,7 @@
     "prismic"
   ],
   "dependencies": {
-    "@imgix/gatsby": "^1.5.0",
+    "@imgix/gatsby": "^1.6.0-rc.1",
     "camel-case": "^4.1.2",
     "fp-ts": "^2.9.5",
     "gatsby-node-helpers": "^1.2.1",

--- a/packages/gatsby-source-prismic/src/builders/buildImageBaseFieldConfigMap.ts
+++ b/packages/gatsby-source-prismic/src/builders/buildImageBaseFieldConfigMap.ts
@@ -49,6 +49,8 @@ export const buildImageBaseFieldConfigMap: RTE.ReaderTaskEither<
     const imgixTypes = imgixGatsby.createImgixGatsbyTypes({
       cache: deps.cache,
       resolveUrl,
+      resolveWidth,
+      resolveHeight,
       defaultParams: deps.pluginOptions.imageImgixParams,
       namespace: 'Imgix',
     })

--- a/packages/gatsby-source-prismic/src/builders/buildImageBaseFieldConfigMap.ts
+++ b/packages/gatsby-source-prismic/src/builders/buildImageBaseFieldConfigMap.ts
@@ -47,6 +47,7 @@ export const buildImageBaseFieldConfigMap: RTE.ReaderTaskEither<
   gqlc.ObjectTypeComposerFieldConfigMapDefinition<PrismicAPIImageField, unknown>
 > = pipe(
   RTE.asks((deps) => {
+    // ⚠️ These options need to be kept in sync with the options at packages/gatsby-source-prismic/src/builders/buildImgixImageTypes.ts
     const imgixTypes = imgixGatsby.createImgixGatsbyTypes({
       cache: deps.cache,
       resolveUrl,

--- a/packages/gatsby-source-prismic/src/builders/buildImageBaseFieldConfigMap.ts
+++ b/packages/gatsby-source-prismic/src/builders/buildImageBaseFieldConfigMap.ts
@@ -1,8 +1,9 @@
-import * as imgixGatsby from '@imgix/gatsby/dist/pluginHelpers'
-import { pipe } from 'fp-ts/function'
-import * as RTE from 'fp-ts/ReaderTaskEither'
-import * as gatsbyFs from 'gatsby-source-filesystem'
 import * as gqlc from 'graphql-compose'
+import * as gatsbyFs from 'gatsby-source-filesystem'
+import * as imgixGatsby from '@imgix/gatsby/dist/pluginHelpers'
+import * as RTE from 'fp-ts/ReaderTaskEither'
+import { pipe } from 'fp-ts/function'
+
 import { Dependencies, PrismicAPIImageField } from '../types'
 
 /**

--- a/packages/gatsby-source-prismic/src/builders/buildImageBaseFieldConfigMap.ts
+++ b/packages/gatsby-source-prismic/src/builders/buildImageBaseFieldConfigMap.ts
@@ -55,13 +55,6 @@ export const buildImageBaseFieldConfigMap: RTE.ReaderTaskEither<
       namespace: 'Imgix',
     })
 
-    const types = [
-      ...imgixTypes.types.map(deps.schema.buildObjectType),
-      ...imgixTypes.enumTypes.map(deps.schema.buildEnumType),
-      ...imgixTypes.inputTypes.map(deps.schema.buildInputObjectType),
-    ]
-    deps.createTypes(types)
-
     return {
       alt: 'String',
       copyright: 'String',

--- a/packages/gatsby-source-prismic/src/builders/buildImgixImageTypes.ts
+++ b/packages/gatsby-source-prismic/src/builders/buildImgixImageTypes.ts
@@ -1,5 +1,5 @@
 import * as gatsby from 'gatsby'
-import * as gatsbyImgix from 'gatsby-plugin-imgix/dist/node'
+import * as imgixGatsby from '@imgix/gatsby/dist/pluginHelpers'
 import * as RTE from 'fp-ts/ReaderTaskEither'
 import { pipe } from 'fp-ts/function'
 
@@ -15,15 +15,17 @@ export const buildImgixImageTypes: RTE.ReaderTaskEither<
   never,
   gatsby.GatsbyGraphQLType[]
 > = pipe(
-  RTE.asks((deps) =>
-    gatsbyImgix.createImgixTypes({
-      fixedTypeName: deps.nodeHelpers.createTypeName('ImageFixedType'),
-      fluidTypeName: deps.nodeHelpers.createTypeName('ImageFluidType'),
-      paramsInputTypeName: deps.globalNodeHelpers.createTypeName(
-        'ImgixUrlParamsInput',
-      ),
+  RTE.asks((deps) => {
+    const imgixTypes = imgixGatsby.createImgixGatsbyTypes({
       cache: deps.cache,
-      schema: deps.schema,
-    }),
-  ),
+      resolveUrl: () => '',
+      namespace: 'Imgix',
+    })
+
+    return [
+      ...imgixTypes.types.map(deps.schema.buildObjectType),
+      ...imgixTypes.enumTypes.map(deps.schema.buildEnumType),
+      ...imgixTypes.inputTypes.map(deps.schema.buildInputObjectType),
+    ]
+  }),
 )

--- a/packages/gatsby-source-prismic/src/builders/buildImgixImageTypes.ts
+++ b/packages/gatsby-source-prismic/src/builders/buildImgixImageTypes.ts
@@ -16,9 +16,10 @@ export const buildImgixImageTypes: RTE.ReaderTaskEither<
   gatsby.GatsbyGraphQLType[]
 > = pipe(
   RTE.asks((deps) => {
+    // ⚠️ These options need to be kept in sync with the options at packages/gatsby-source-prismic/src/builders/buildImageBaseFieldConfigMap.ts
     const imgixTypes = imgixGatsby.createImgixGatsbyTypes({
       cache: deps.cache,
-      resolveUrl: () => '',
+      resolveUrl: () => '', // Doesn't matter
       namespace: 'Imgix',
     })
 

--- a/packages/gatsby-source-prismic/src/create-schema-customization.ts
+++ b/packages/gatsby-source-prismic/src/create-schema-customization.ts
@@ -1,29 +1,25 @@
-import * as gatsby from 'gatsby'
+import * as A from 'fp-ts/Array'
+import { constVoid, pipe } from 'fp-ts/function'
 import * as RTE from 'fp-ts/ReaderTaskEither'
 import * as R from 'fp-ts/Record'
-import * as A from 'fp-ts/Array'
-import * as TE from 'fp-ts/TaskEither'
 import * as T from 'fp-ts/Task'
-import { pipe, constVoid } from 'fp-ts/function'
-
-import { createAllDocumentTypesType } from './lib/createAllDocumentTypesType'
-import { createCustomType } from './lib/createCustomType'
-import { createTypes } from './lib/createTypes'
-import { throwError } from './lib/throwError'
-
+import * as TE from 'fp-ts/TaskEither'
+import * as gatsby from 'gatsby'
+import { buildDependencies } from './buildDependencies'
 import { buildEmbedType } from './builders/buildEmbedType'
 import { buildGeoPointType } from './builders/buildGeoPointType'
 import { buildImageDimensionsType } from './builders/buildImageDimensionsType'
 import { buildImageThumbnailType } from './builders/buildImageThumbnailType'
-import { buildImgixImageTypes } from './builders/buildImgixImageTypes'
 import { buildLinkType } from './builders/buildLinkType'
 import { buildLinkTypeEnumType } from './builders/buildLinkTypeEnumType'
 import { buildSliceInterface } from './builders/buildSliceInterface'
 import { buildStructuredTextType } from './builders/buildStructuredTextType'
 import { buildTypePathType } from './builders/buildTypePathType'
-
+import { createAllDocumentTypesType } from './lib/createAllDocumentTypesType'
+import { createCustomType } from './lib/createCustomType'
+import { createTypes } from './lib/createTypes'
+import { throwError } from './lib/throwError'
 import { Dependencies, Mutable, PluginOptions } from './types'
-import { buildDependencies } from './buildDependencies'
 
 const GatsbyGraphQLTypeM = A.getMonoid<gatsby.GatsbyGraphQLType>()
 
@@ -54,11 +50,10 @@ export const createBaseTypes: RTE.ReaderTaskEither<
       RTE.sequenceArray,
     ),
   ),
-  RTE.bind('imgixTypes', () => buildImgixImageTypes),
   RTE.map((scope) =>
     GatsbyGraphQLTypeM.concat(
       scope.baseTypes as Mutable<typeof scope.baseTypes>,
-      scope.imgixTypes,
+      [],
     ),
   ),
   RTE.chain(createTypes),

--- a/packages/gatsby-source-prismic/src/create-schema-customization.ts
+++ b/packages/gatsby-source-prismic/src/create-schema-customization.ts
@@ -1,11 +1,16 @@
-import * as A from 'fp-ts/Array'
-import { constVoid, pipe } from 'fp-ts/function'
+import * as gatsby from 'gatsby'
 import * as RTE from 'fp-ts/ReaderTaskEither'
 import * as R from 'fp-ts/Record'
-import * as T from 'fp-ts/Task'
+import * as A from 'fp-ts/Array'
 import * as TE from 'fp-ts/TaskEither'
-import * as gatsby from 'gatsby'
-import { buildDependencies } from './buildDependencies'
+import * as T from 'fp-ts/Task'
+import { pipe, constVoid } from 'fp-ts/function'
+
+import { createAllDocumentTypesType } from './lib/createAllDocumentTypesType'
+import { createCustomType } from './lib/createCustomType'
+import { createTypes } from './lib/createTypes'
+import { throwError } from './lib/throwError'
+
 import { buildEmbedType } from './builders/buildEmbedType'
 import { buildGeoPointType } from './builders/buildGeoPointType'
 import { buildImageDimensionsType } from './builders/buildImageDimensionsType'
@@ -16,11 +21,9 @@ import { buildLinkTypeEnumType } from './builders/buildLinkTypeEnumType'
 import { buildSliceInterface } from './builders/buildSliceInterface'
 import { buildStructuredTextType } from './builders/buildStructuredTextType'
 import { buildTypePathType } from './builders/buildTypePathType'
-import { createAllDocumentTypesType } from './lib/createAllDocumentTypesType'
-import { createCustomType } from './lib/createCustomType'
-import { createTypes } from './lib/createTypes'
-import { throwError } from './lib/throwError'
+
 import { Dependencies, Mutable, PluginOptions } from './types'
+import { buildDependencies } from './buildDependencies'
 
 const GatsbyGraphQLTypeM = A.getMonoid<gatsby.GatsbyGraphQLType>()
 
@@ -52,7 +55,6 @@ export const createBaseTypes: RTE.ReaderTaskEither<
     ),
   ),
   RTE.bind('imgixTypes', () => buildImgixImageTypes),
-
   RTE.map((scope) =>
     GatsbyGraphQLTypeM.concat(
       scope.baseTypes as Mutable<typeof scope.baseTypes>,

--- a/packages/gatsby-source-prismic/src/create-schema-customization.ts
+++ b/packages/gatsby-source-prismic/src/create-schema-customization.ts
@@ -10,6 +10,7 @@ import { buildEmbedType } from './builders/buildEmbedType'
 import { buildGeoPointType } from './builders/buildGeoPointType'
 import { buildImageDimensionsType } from './builders/buildImageDimensionsType'
 import { buildImageThumbnailType } from './builders/buildImageThumbnailType'
+import { buildImgixImageTypes } from './builders/buildImgixImageTypes'
 import { buildLinkType } from './builders/buildLinkType'
 import { buildLinkTypeEnumType } from './builders/buildLinkTypeEnumType'
 import { buildSliceInterface } from './builders/buildSliceInterface'
@@ -50,10 +51,12 @@ export const createBaseTypes: RTE.ReaderTaskEither<
       RTE.sequenceArray,
     ),
   ),
+  RTE.bind('imgixTypes', () => buildImgixImageTypes),
+
   RTE.map((scope) =>
     GatsbyGraphQLTypeM.concat(
       scope.baseTypes as Mutable<typeof scope.baseTypes>,
-      [],
+      scope.imgixTypes,
     ),
   ),
   RTE.chain(createTypes),

--- a/yarn.lock
+++ b/yarn.lock
@@ -1602,10 +1602,10 @@
   resolved "https://registry.yarnpkg.com/@iarna/toml/-/toml-2.2.5.tgz#b32366c89b43c6f8cefbdefac778b9c828e3ba8c"
   integrity sha512-trnsAYxU3xnS1gPHPyU961coFyLkh4gAD/0zQ5mymY4yOZ+CYvsPqUbOFSw0aDM4y0tV7tiFxL/1XfXPNC6IPg==
 
-"@imgix/gatsby@^1.6.0-rc.1":
-  version "1.6.0-rc.1"
-  resolved "https://registry.yarnpkg.com/@imgix/gatsby/-/gatsby-1.6.0-rc.1.tgz#9ad537bc844092f886173fb057f77f5746c54193"
-  integrity sha512-GpHSHbEVJMsS28gk4WGwPF3F0q7Rl5R11dSB0NCSgHr3mRhyBvNOkzhTaUmD0JCwfZDd0KxEuaRlh61CTR1Yeg==
+"@imgix/gatsby@^1.6.0-rc.3":
+  version "1.6.0-rc.3"
+  resolved "https://registry.yarnpkg.com/@imgix/gatsby/-/gatsby-1.6.0-rc.3.tgz#2972f035d8e3acfc336868cb24eca7681d4a56c3"
+  integrity sha512-yJ895vu7SwMuxIZ/LHja92eVXx1yK512mPiJMsv0U1Oy2BKCTG0EXuWBm8t2NE/Pfh/a+O6J17EJBndVxptB2g==
   dependencies:
     "@imgix/js-core" "3.1.3"
     camel-case "^4.1.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1602,6 +1602,34 @@
   resolved "https://registry.yarnpkg.com/@iarna/toml/-/toml-2.2.5.tgz#b32366c89b43c6f8cefbdefac778b9c828e3ba8c"
   integrity sha512-trnsAYxU3xnS1gPHPyU961coFyLkh4gAD/0zQ5mymY4yOZ+CYvsPqUbOFSw0aDM4y0tV7tiFxL/1XfXPNC6IPg==
 
+"@imgix/gatsby@^1.5.0":
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/@imgix/gatsby/-/gatsby-1.5.0.tgz#674d54f1b668b02bb677ece688096948f86c5526"
+  integrity sha512-GX7HraKsuHNtZ+epEGFHE8EGoRQbZS8yxebozMRE/3yODDMsMdAhxD6CMHkl16Z88Q4R5k1ONcIDEUb29+e2PA==
+  dependencies:
+    "@imgix/js-core" "3.1.1"
+    camel-case "^4.1.2"
+    common-tags "^1.8.0"
+    debug "^4.3.1"
+    fp-ts "^2.9.3"
+    fp-ts-contrib "^0.1.18"
+    graphql-compose "^7.25.0"
+    imgix-url-params "^11.11.2"
+    io-ts "^2.2.13"
+    io-ts-reporters "^1.2.2"
+    jsuri "^1.3.1"
+    node-fetch "^2.6.0"
+    ramda "^0.27.1"
+    read-pkg-up "^7.0.1"
+
+"@imgix/js-core@3.1.1":
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/@imgix/js-core/-/js-core-3.1.1.tgz#04d4b33e3f7409c7145642a5c3315d4d0ced00e0"
+  integrity sha512-tIGTl97MWwGNjPQ8Ar3/ZWBWwHuf4+94ZBoo0zp0/5+a9D583ApriN5HpLqgfubTLStB5x04LxDZYS6BHzTFFA==
+  dependencies:
+    js-base64 "~2.6.0"
+    md5 "^2.2.1"
+
 "@jest/types@^25.5.0":
   version "25.5.0"
   resolved "https://registry.yarnpkg.com/@jest/types/-/types-25.5.0.tgz#4d6a4793f7b9599fc3680877b856a97dbccf2a9d"
@@ -8357,10 +8385,15 @@ forwarded@~0.1.2:
   resolved "https://registry.yarnpkg.com/forwarded/-/forwarded-0.1.2.tgz#98c23dab1175657b8c0573e8ceccd91b0ff18c84"
   integrity sha1-mMI9qxF1ZXuMBXPozszZGw/xjIQ=
 
-fp-ts@^2.9.5:
-  version "2.10.4"
-  resolved "https://registry.yarnpkg.com/fp-ts/-/fp-ts-2.10.4.tgz#f81f34b1c15b3255d65cdbb39508ebb42922aa0c"
-  integrity sha512-vMTB5zNc9PnE20q145PNbkiL9P9WegwmKVOFloi/NfHnPdAlcob6I3AKqlH/9u3k3/M/GOftZhcJdBrb+NtnDA==
+fp-ts-contrib@^0.1.18:
+  version "0.1.21"
+  resolved "https://registry.yarnpkg.com/fp-ts-contrib/-/fp-ts-contrib-0.1.21.tgz#9a2b6c108ad9487922890f46219d5639f3cacc66"
+  integrity sha512-Wa1wXpeDDVyPiTZaxbas+y6pigKxiZlf/xzUBhFJ5bPNAsOrzNfFeQliu3bIH9ZjYWrt6HIMuNXAejPh6oSSkA==
+
+fp-ts@^2.9.3, fp-ts@^2.9.5:
+  version "2.9.5"
+  resolved "https://registry.yarnpkg.com/fp-ts/-/fp-ts-2.9.5.tgz#6690cd8b76b84214a38fc77cbbbd04a38f86ea90"
+  integrity sha512-MiHrA5teO6t8zKArE3DdMPT/Db6v2GUt5yfWnhBTrrsVfeCJUUnV6sgFvjGNBKDmEMqVwRFkEePL7wPwqrLKKA==
 
 fraction.js@^4.0.13:
   version "4.0.13"
@@ -9327,7 +9360,7 @@ graceful-fs@^4.1.11, graceful-fs@^4.1.15, graceful-fs@^4.1.2, graceful-fs@^4.1.5
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.6.tgz#ff040b2b0853b23c3d31027523706f1885d76bee"
   integrity sha512-nTnJ528pbqxYanhpDYsi4Rd8MAeaBA67+RZ10CM1m3bTAVFEDcd5AuA4a6W5YkGZ1iNXHzZz8T6TBKLeBuNriQ==
 
-graphql-compose@~7.25.0:
+graphql-compose@^7.25.0, graphql-compose@~7.25.0:
   version "7.25.1"
   resolved "https://registry.yarnpkg.com/graphql-compose/-/graphql-compose-7.25.1.tgz#9d89f72781931590d4dfca6a709f381f2f76b873"
   integrity sha512-TPXTe1BoQkMjp/MH93yA0SQo8PiXxJAv6Eo6K/+kpJELM9l2jZnd5PCduweuXFcKv+nH973wn/VYzYKDMQ9YoQ==
@@ -10218,6 +10251,16 @@ invariant@^2.2.3, invariant@^2.2.4:
   dependencies:
     loose-envify "^1.0.0"
 
+io-ts-reporters@^1.2.2:
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/io-ts-reporters/-/io-ts-reporters-1.2.2.tgz#4d3219777ea5219c7d8f6ffac01fd68e72426dd1"
+  integrity sha512-igASwWWkDY757OutNcM6zTtdJf/eTZYkoe2ymsX2qpm5bKZLo74FJYjsCtMQOEdY7dRHLLEulCyFQwdN69GBCg==
+
+io-ts@^2.2.13:
+  version "2.2.16"
+  resolved "https://registry.yarnpkg.com/io-ts/-/io-ts-2.2.16.tgz#597dffa03db1913fc318c9c6df6931cb4ed808b2"
+  integrity sha512-y5TTSa6VP6le0hhmIyN0dqEXkrZeJLeC5KApJq6VLci3UEKF80lZ+KuoUs02RhBxNWlrqSNxzfI7otLX1Euv8Q==
+
 ip-regex@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/ip-regex/-/ip-regex-2.1.0.tgz#fa78bf5d2e6913c911ce9f819ee5146bb6d844e9"
@@ -10917,6 +10960,11 @@ joi@^17.2.1, joi@^17.4.0:
     "@sideway/formula" "^3.0.0"
     "@sideway/pinpoint" "^2.0.0"
 
+js-base64@~2.6.0:
+  version "2.6.4"
+  resolved "https://registry.yarnpkg.com/js-base64/-/js-base64-2.6.4.tgz#f4e686c5de1ea1f867dbcad3d46d969428df98c4"
+  integrity sha512-pZe//GGmwJndub7ZghVHz7vjb2LgC1m8B07Au3eYqeqv9emhESByMXxaEgkUkEqJe87oBbSniGYoQNIBklc7IQ==
+
 js-levenshtein@^1.1.6:
   version "1.1.6"
   resolved "https://registry.yarnpkg.com/js-levenshtein/-/js-levenshtein-1.1.6.tgz#c6cee58eb3550372df8deb85fad5ce66ce01d59d"
@@ -11179,6 +11227,11 @@ jsprim@^1.2.2:
     extsprintf "1.3.0"
     json-schema "0.2.3"
     verror "1.10.0"
+
+jsuri@^1.3.1:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/jsuri/-/jsuri-1.3.1.tgz#cd93fc6a87b255142cb7b0f479f00517ab9395ed"
+  integrity sha1-zZP8aoeyVRQst7D0efAFF6uTle0=
 
 "jsx-ast-utils@^2.4.1 || ^3.0.0", jsx-ast-utils@^3.1.0:
   version "3.2.0"
@@ -11885,7 +11938,7 @@ md5.js@^1.3.4:
     inherits "^2.0.1"
     safe-buffer "^5.1.2"
 
-md5@^2.3.0:
+md5@^2.2.1, md5@^2.3.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/md5/-/md5-2.3.0.tgz#c3da9a6aae3a30b46b7b0c349b87b110dc3bda4f"
   integrity sha512-T1GITYmFaKuO91vxyoQMFETst+O71VUPEU3ze5GNzDm0OWdP8v1ziTaAEPUr/3kLsY3Sftgz242A1SetQiDL7g==
@@ -12632,7 +12685,7 @@ node-eta@^0.9.0:
   resolved "https://registry.yarnpkg.com/node-eta/-/node-eta-0.9.0.tgz#9fb0b099bcd2a021940e603c64254dc003d9a7a8"
   integrity sha1-n7CwmbzSoCGUDmA8ZCVNwAPZp6g=
 
-node-fetch@2.6.1, node-fetch@^2.5.0, node-fetch@^2.6.1:
+node-fetch@2.6.1, node-fetch@^2.5.0, node-fetch@^2.6.0, node-fetch@^2.6.1:
   version "2.6.1"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.1.tgz#045bd323631f76ed2e2b55573394416b639a0052"
   integrity sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==
@@ -14703,6 +14756,11 @@ ramda@^0.21.0:
   version "0.21.0"
   resolved "https://registry.yarnpkg.com/ramda/-/ramda-0.21.0.tgz#a001abedb3ff61077d4ff1d577d44de77e8d0a35"
   integrity sha1-oAGr7bP/YQd9T/HVd9RN536NCjU=
+
+ramda@^0.27.1:
+  version "0.27.1"
+  resolved "https://registry.yarnpkg.com/ramda/-/ramda-0.27.1.tgz#66fc2df3ef873874ffc2da6aa8984658abacf5c9"
+  integrity sha512-PgIdVpn5y5Yns8vqb8FzBUEYn98V3xcPgawAkkgj0YJ0qDsnHCiNmZYfOGMgOvoB0eWFLpYbhxUR3mxfDIMvpw==
 
 randombytes@^2.0.0, randombytes@^2.0.1, randombytes@^2.0.5, randombytes@^2.1.0:
   version "2.1.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1602,12 +1602,12 @@
   resolved "https://registry.yarnpkg.com/@iarna/toml/-/toml-2.2.5.tgz#b32366c89b43c6f8cefbdefac778b9c828e3ba8c"
   integrity sha512-trnsAYxU3xnS1gPHPyU961coFyLkh4gAD/0zQ5mymY4yOZ+CYvsPqUbOFSw0aDM4y0tV7tiFxL/1XfXPNC6IPg==
 
-"@imgix/gatsby@^1.5.0":
-  version "1.5.0"
-  resolved "https://registry.yarnpkg.com/@imgix/gatsby/-/gatsby-1.5.0.tgz#674d54f1b668b02bb677ece688096948f86c5526"
-  integrity sha512-GX7HraKsuHNtZ+epEGFHE8EGoRQbZS8yxebozMRE/3yODDMsMdAhxD6CMHkl16Z88Q4R5k1ONcIDEUb29+e2PA==
+"@imgix/gatsby@^1.6.0-rc.1":
+  version "1.6.0-rc.1"
+  resolved "https://registry.yarnpkg.com/@imgix/gatsby/-/gatsby-1.6.0-rc.1.tgz#9ad537bc844092f886173fb057f77f5746c54193"
+  integrity sha512-GpHSHbEVJMsS28gk4WGwPF3F0q7Rl5R11dSB0NCSgHr3mRhyBvNOkzhTaUmD0JCwfZDd0KxEuaRlh61CTR1Yeg==
   dependencies:
-    "@imgix/js-core" "3.1.1"
+    "@imgix/js-core" "3.1.3"
     camel-case "^4.1.2"
     common-tags "^1.8.0"
     debug "^4.3.1"
@@ -1622,10 +1622,10 @@
     ramda "^0.27.1"
     read-pkg-up "^7.0.1"
 
-"@imgix/js-core@3.1.1":
-  version "3.1.1"
-  resolved "https://registry.yarnpkg.com/@imgix/js-core/-/js-core-3.1.1.tgz#04d4b33e3f7409c7145642a5c3315d4d0ced00e0"
-  integrity sha512-tIGTl97MWwGNjPQ8Ar3/ZWBWwHuf4+94ZBoo0zp0/5+a9D583ApriN5HpLqgfubTLStB5x04LxDZYS6BHzTFFA==
+"@imgix/js-core@3.1.3":
+  version "3.1.3"
+  resolved "https://registry.yarnpkg.com/@imgix/js-core/-/js-core-3.1.3.tgz#9c26366f84f59e6c238c41455f45aacdf04862b7"
+  integrity sha512-7HUIFy4dq9wLSJURgPhglSni50rt3af4cAyBip14koR5oPIGgTGs0W41aQZc5gyCesh7jZaSjm4VxiwqS7gszw==
   dependencies:
     js-base64 "~2.6.0"
     md5 "^2.2.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1602,10 +1602,10 @@
   resolved "https://registry.yarnpkg.com/@iarna/toml/-/toml-2.2.5.tgz#b32366c89b43c6f8cefbdefac778b9c828e3ba8c"
   integrity sha512-trnsAYxU3xnS1gPHPyU961coFyLkh4gAD/0zQ5mymY4yOZ+CYvsPqUbOFSw0aDM4y0tV7tiFxL/1XfXPNC6IPg==
 
-"@imgix/gatsby@^1.6.0-rc.3":
-  version "1.6.0-rc.3"
-  resolved "https://registry.yarnpkg.com/@imgix/gatsby/-/gatsby-1.6.0-rc.3.tgz#2972f035d8e3acfc336868cb24eca7681d4a56c3"
-  integrity sha512-yJ895vu7SwMuxIZ/LHja92eVXx1yK512mPiJMsv0U1Oy2BKCTG0EXuWBm8t2NE/Pfh/a+O6J17EJBndVxptB2g==
+"@imgix/gatsby@^1.6.0":
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/@imgix/gatsby/-/gatsby-1.6.0.tgz#c4287b0173370132d5df4987c1d6178b4a5377fa"
+  integrity sha512-l/wo1/NIMr2976wPP/egrKjmYuPKBXpAx8dsSHdzdNsd0DaZWR8P/P7Epf18RzHVTtJUNyq6OkTA1rMzxdc+4Q==
   dependencies:
     "@imgix/js-core" "3.1.3"
     camel-case "^4.1.2"


### PR DESCRIPTION
Hey there Prismic (and @angeloashmore) 👋 

This PR is the start of the process to migrating the Prismic Imgix GraphQL field types over to use @imgix/gatsby internally. A significant benefit of doing this is that the new Gatsby image plugin, gatsby-plugin-image, is supported out of the box.

This PR is not “finished”, but I believe it is in a working state. I’m opening this at an early stage to ensure that I’m going down a path that Prismic is happy with (i.e. in terms of the code) and to get feedback on ways that I could architect the code differently, if the target branch is correct, or if there is any more work to be done (e.g. tests?). @angeloashmore I still have your message about the potential issue you raised on Slack saved, and I’m looking to investigate that this week.

Feel free to review this properly now, or wait a bit longer until I’m fully satisfied that it’s working correctly, and then do a review then. Either way I’m open and would be grateful for feedback!