### PR TITLE
feat: add customTypesApiEndpoint option

### DIFF
--- a/packages/gatsby-source-prismic/README.md
+++ b/packages/gatsby-source-prismic/README.md
@@ -166,6 +166,12 @@ module.exports = {
         // endpoint will be used.
         apiEndpoint: process.env.PRISMIC_API_ENDPOINT,
 
+        // The API endpoint used to automatically fetch custom types from
+        // Prismic. You can omit this option in most cases unless you require
+        // an API proxy or need to mock network responses. By default, Prismic's
+        // standard endpoint will be used.
+        customTypesApiEndpoint: process.env.PRISMIC_CUSTOM_TYPES_API_ENDPOINT,
+
         // A prefix used for all GraphQL types for your Prismic repository. If
         // you are sourcing from multiple repositories, each plugin should have
         // a unique typePrefix to avoid type conflicts. This is optional if you

--- a/packages/gatsby-source-prismic/src/constants.ts
+++ b/packages/gatsby-source-prismic/src/constants.ts
@@ -18,7 +18,7 @@ export const PRISMIC_API_NON_DATA_FIELDS = ['uid']
  *
  * @see https://prismic.io/docs/technologies/custom-types-api
  */
-export const PRISMIC_CUSTOM_TYPES_API_ENDPOINT =
+export const DEFAULT_CUSTOM_TYPES_API_ENDPOINT =
   'https://customtypes.prismic.io/customtypes'
 
 /**

--- a/packages/gatsby-source-prismic/src/plugin-options-schema.ts
+++ b/packages/gatsby-source-prismic/src/plugin-options-schema.ts
@@ -21,7 +21,7 @@ import {
   MISSING_SCHEMAS_MSG,
   MISSING_SCHEMA_MSG,
   COULD_NOT_ACCESS_MSG,
-  PRISMIC_CUSTOM_TYPES_API_ENDPOINT,
+  DEFAULT_CUSTOM_TYPES_API_ENDPOINT,
 } from './constants'
 import {
   Dependencies,
@@ -65,7 +65,7 @@ const externalCustomTypeFetchingProgram = (
       RTE.fromTaskEither(
         TE.tryCatch(
           () =>
-            got(PRISMIC_CUSTOM_TYPES_API_ENDPOINT, {
+            got(scope.pluginOptions.customTypesApiEndpoint, {
               headers: scope.headers,
             }).json<PrismicCustomTypeApiResponse>(),
           () =>
@@ -173,9 +173,12 @@ export const pluginOptionsSchema: NonNullable<
   const schema = Joi.object({
     repositoryName: Joi.string().required(),
     accessToken: Joi.string(),
-    customTypesApiToken: Joi.string(),
     apiEndpoint: Joi.string().default((parent) =>
       prismic.defaultEndpoint(parent.repositoryName),
+    ),
+    customTypesApiToken: Joi.string(),
+    customTypesApiEndpoint: Joi.string().default(
+      DEFAULT_CUSTOM_TYPES_API_ENDPOINT,
     ),
     releaseID: Joi.string(),
     fetchLinks: Joi.array().items(Joi.string().required()),

--- a/packages/gatsby-source-prismic/src/types.ts
+++ b/packages/gatsby-source-prismic/src/types.ts
@@ -58,8 +58,9 @@ export interface Dependencies {
 export interface PluginOptions extends gatsby.PluginOptions {
   repositoryName: string
   accessToken?: string
-  customTypesApiToken?: string
   apiEndpoint: string
+  customTypesApiToken?: string
+  customTypesApiEndpoint: string
   releaseID?: string
   graphQuery?: string
   fetchLinks?: string[]

--- a/packages/gatsby-source-prismic/test/__testutils__/createCustomTypesAPIMockedRequest.ts
+++ b/packages/gatsby-source-prismic/test/__testutils__/createCustomTypesAPIMockedRequest.ts
@@ -3,22 +3,22 @@ import * as msw from 'msw'
 import { PluginOptions, PrismicCustomTypeApiResponse } from '../../src'
 
 export const createCustomTypesAPIMockedRequest = (
-  pluginOptions: Pick<PluginOptions, 'repositoryName' | 'customTypesApiToken'>,
+  pluginOptions: Pick<
+    PluginOptions,
+    'repositoryName' | 'customTypesApiToken' | 'customTypesApiEndpoint'
+  >,
   response: PrismicCustomTypeApiResponse,
 ): msw.RestHandler =>
-  msw.rest.get(
-    'https://customtypes.prismic.io/customtypes',
-    (req, res, ctx) => {
-      const repositoryHeader = req.headers.get('repository')
-      const authorizationHeader = req.headers.get('Authorization')
+  msw.rest.get(pluginOptions.customTypesApiEndpoint, (req, res, ctx) => {
+    const repositoryHeader = req.headers.get('repository')
+    const authorizationHeader = req.headers.get('Authorization')
 
-      if (
-        repositoryHeader === pluginOptions.repositoryName &&
-        authorizationHeader === `Bearer ${pluginOptions.customTypesApiToken}`
-      ) {
-        return res(ctx.json(response))
-      } else {
-        return res(ctx.status(401))
-      }
-    },
-  )
+    if (
+      repositoryHeader === pluginOptions.repositoryName &&
+      authorizationHeader === `Bearer ${pluginOptions.customTypesApiToken}`
+    ) {
+      return res(ctx.json(response))
+    } else {
+      return res(ctx.status(401))
+    }
+  })

--- a/packages/gatsby-source-prismic/test/plugin-options-schema.test.ts
+++ b/packages/gatsby-source-prismic/test/plugin-options-schema.test.ts
@@ -25,7 +25,8 @@ test.serial('passes on valid options', async (t) => {
     repositoryName: 'string',
     accessToken: 'string',
     customTypesApiToken: 'string',
-    apiEndpoint: 'https://example.com',
+    customTypesApiEndpoint: 'https://example-customTypesApiEndpoint.com',
+    apiEndpoint: 'https://example-apiEndpoint.com',
     releaseID: 'string',
     graphQuery: 'string',
     lang: 'string',
@@ -77,6 +78,7 @@ test.serial('fails on invalid options', async (t) => {
     repositoryName: Symbol(),
     accessToken: Symbol(),
     customTypesApiToken: Symbol(),
+    customTypesApiEndpoint: Symbol(),
     apiEndpoint: Symbol(),
     releaseID: Symbol(),
     graphQuery: Symbol(),
@@ -96,8 +98,9 @@ test.serial('fails on invalid options', async (t) => {
   t.deepEqual(res.errors, [
     '"repositoryName" must be a string',
     '"accessToken" must be a string',
-    '"customTypesApiToken" must be a string',
     '"apiEndpoint" must be a string',
+    '"customTypesApiToken" must be a string',
+    '"customTypesApiEndpoint" must be a string',
     '"releaseID" must be a string',
     '"graphQuery" must be a string',
     '"lang" must be a string',
@@ -152,6 +155,7 @@ test.serial('allows only one of qraphQuery or fetchLinks', async (t) => {
 test.serial('checks that all schemas are provided', async (t) => {
   const pluginOptions = {
     repositoryName: 'qwerty',
+    customTypesApiEndpoint: 'https://example.com',
     schemas: { page: kitchenSinkSchemaFixture },
   }
   const apiEndpoint = prismic.defaultEndpoint(pluginOptions.repositoryName)
@@ -181,6 +185,7 @@ test.serial(
     const pluginOptions = {
       repositoryName: 'qwerty',
       customTypesApiToken: 'customTypesApiToken',
+      customTypesApiEndpoint: 'https://example.com',
     }
     const apiEndpoint = prismic.defaultEndpoint(pluginOptions.repositoryName)
 
@@ -235,6 +240,7 @@ test.serial(
     const pluginOptions = {
       repositoryName: 'qwerty',
       customTypesApiToken: 'customTypesApiToken',
+      customTypesApiEndpoint: 'https://example.com',
       schemas: {
         [customTypeNotInAPI.id]: customTypeNotInAPI.json,
         // Note that we are going to replace customTypeInAPI2 with


### PR DESCRIPTION
Adds the ability to configure the Custom Types API endpoint. It will continue to default to `https://customtypes.prismic.io/customtypes`.

Implemented per @MarcMcIntosh's review (#349).
