### PR TITLE
feat: restructure preview config

### DIFF
--- a/packages/gatsby-plugin-prismic-previews/README.md
+++ b/packages/gatsby-plugin-prismic-previews/README.md
@@ -201,9 +201,12 @@ const PreviewPage = () => {
   )
 }
 
-export default withPrismicPreviewResolver(PreviewPage, {
-  [process.env.GATSBY_PRISMIC_REPOSITORY_NAME]: { linkResolver },
-})
+export default withPrismicPreviewResolver(PreviewPage, [
+  {
+    repositoryName: process.env.GATSBY_PRISMIC_REPOSITORY_NAME,
+    linkResolver,
+  },
+])
 ```
 
 You can see that the Link Resolver provided to `withPrismicPreviewResolver()` is
@@ -216,14 +219,16 @@ from two repositories, each with their own Link Resolver, your
 import { mainLinkResolver } from '../mainLinkResolver'
 import { secondaryLinkResolver } from '../secondaryLinkResolver'
 
-export default withPrismicPreviewResolver(PreviewPage, {
-  [process.env.GATSBY_PRISMIC_MAIN_REPOSITORY_NAME]: {
+export default withPrismicPreviewResolver(PreviewPage, [
+  {
+    repositoryName: process.env.GATSBY_PRISMIC_MAIN_REPOSITORY_NAME,
     linkResolver: mainLinkResolver,
   },
-  [process.env.GATSBY_PRISMIC_SECONDARY_REPOSITORY_NAME]: {
+  {
+    repositoryName: process.env.GATSBY_PRISMIC_SECONDARY_REPOSITORY_NAME,
     linkResolver: secondaryLinkResolver,
   },
-})
+])
 ```
 
 For more details on setting up a preview resolver page and the available
@@ -265,9 +270,12 @@ const PageTemplate = ({ data }) => {
   )
 }
 
-export default withPrismicPreview(PageTemplate, {
-  [process.env.GATSBY_PRISMIC_REPOSITORY_NAME]: { linkResolver },
-})
+export default withPrismicPreview(PageTemplate, [
+  {
+    repositoryName: process.env.GATSBY_PRISMIC_REPOSITORY_NAME,
+    linkResolver,
+  },
+])
 
 export const query = graphql`
   query PageTemplate($id: ID!) {
@@ -303,14 +311,16 @@ from two repositories, each with their own Link Resolver, your
 import { mainLinkResolver } from '../mainLinkResolver'
 import { secondaryLinkResolver } from '../secondaryLinkResolver'
 
-export default withPrismicPreview(PageTemplate, {
-  [process.env.GATSBY_PRISMIC_MAIN_REPOSITORY_NAME]: {
+export default withPrismicPreview(PageTemplate, [
+  {
+    repositoryName: process.env.GATSBY_PRISMIC_MAIN_REPOSITORY_NAME,
     linkResolver: mainLinkResolver,
   },
-  [process.env.GATSBY_PRISMIC_SECONDARY_REPOSITORY_NAME]: {
+  {
+    repositoryName: process.env.GATSBY_PRISMIC_SECONDARY_REPOSITORY_NAME,
     linkResolver: secondaryLinkResolver,
   },
-})
+])
 ```
 
 For more details on connecting your pages and templates to preview data and the
@@ -337,8 +347,9 @@ import {
   componentResolverFromMap,
 } from 'gatsby-plugin-prismic-previews'
 
-import { PageTemplate } from './PageTemplate'
 import { linkResolver } from '../linkResolver'
+
+import PageTemplate from './PageTemplate'
 
 const NotFoundPage = ({ data }) => {
   const page = data.prismicPage
@@ -350,15 +361,15 @@ const NotFoundPage = ({ data }) => {
   )
 }
 
-export default withPrismicUnpublishedPreview(
-  PageTemplate,
-  { 'my-repository-name': { linkResolver } },
+export default withPrismicUnpublishedPreview(PageTemplate, [
   {
+    repositoryName: 'my-repository-name',
+    linkResolver,
     componentResolver: componentResolverFromMap({
       page: PageTemplate,
     }),
   },
-)
+])
 
 export const query = graphql`
   query NotFoundPage {

--- a/packages/gatsby-plugin-prismic-previews/docs/api-withPrismicPreview.md
+++ b/packages/gatsby-plugin-prismic-previews/docs/api-withPrismicPreview.md
@@ -17,13 +17,12 @@ must mark documents in your query as "previewable." This involves adding a
 ```typescript
 function withPrismicPreview(
   WrappedComponent: React.ComponentType,
-  repositoryConfigs: Record<
-    string,
-    {
-      linkResolver: LinkResolver
-      htmlSerializer?: HTMLSerializer
-    }
-  >,
+  repositoryConfigs: {
+    repositoryName: string
+    linkResolver: LinkResolver
+    htmlSerializer?: HTMLSerializer
+    transformFieldName?: FieldNameTransformer
+  }[],
   config: {
     mergePreviewData?: boolean
   },
@@ -50,10 +49,11 @@ in your app:
   for the configured Prismic repository. This should be the same HTML Serializer
   provided to [`gatsby-source-prismic`][gsp] in your app's `gatsby-config.js`.
 
-- **`transformFieldName`**<br/>The optional field transformer for the configured
-  Prismic repository. This should be the same `transformFieldName` function
-  provided to [`gatsby-source-prismic`][gsp] in your app's `gatsby-config.js` if
-  used. Most projects will not need to provide a value for this option.
+- **`transformFieldName`**<br/>The optional field name transformer for the
+  configured Prismic repository. This should be the same `transformFieldName`
+  function provided to [`gatsby-source-prismic`][gsp] in your app's
+  `gatsby-config.js` if used. Most projects will not need to provide a value for
+  this option.
 
 Configuration values:
 
@@ -96,9 +96,12 @@ const PageTemplate = ({ data }) => {
   )
 }
 
-export default withPrismicPreview(PageTemplate, {
-  'my-repository-name': { linkResolver },
-})
+export default withPrismicPreview(PageTemplate, [
+  {
+    repositoryName: 'my-repository-name',
+    linkResolver,
+  },
+])
 
 export const query = graphql`
   query PageTemplate($id: ID!) {

--- a/packages/gatsby-plugin-prismic-previews/docs/api-withPrismicPreviewResolver.md
+++ b/packages/gatsby-plugin-prismic-previews/docs/api-withPrismicPreviewResolver.md
@@ -22,12 +22,10 @@ updates.
 ```typescript
 function withPrismicPreviewResolver(
   WrappedComponent: React.ComponentType,
-  repositoryConfigs: Record<
-    string,
-    {
-      linkResolver: LinkResolver
-    }
-  >,
+  repositoryConfigs: {
+    repositoryName: string
+    linkResolver: LinkResolver
+  }[],
   config: {
     autoRedirect?: boolean
   },
@@ -85,9 +83,12 @@ const PreviewPage = () => {
   )
 }
 
-export default withPrismicPreviewResolver(PreviewPage, {
-  'my-repository-name': { linkResolver },
-})
+export default withPrismicPreviewResolver(PreviewPage, [
+  {
+    repositoryName: 'my-repository-name',
+    linkResolver,
+  },
+])
 ```
 
 [hoc]: https://reactjs.org/docs/higher-order-components.html

--- a/packages/gatsby-plugin-prismic-previews/docs/api-withPrismicUnpublishedPreview.md
+++ b/packages/gatsby-plugin-prismic-previews/docs/api-withPrismicUnpublishedPreview.md
@@ -21,14 +21,11 @@ appears toward the top of the page. This will hide Gatsby's default development
 ```typescript
 function withPrismicUnpublishedPreview(
   WrappedComponent: React.ComponentType,
-  repositoryConfigs: Record<
-    string,
-    {
-      linkResolver: LinkResolver
-      htmlSerializer?: HTMLSerializer
-    }
-  >,
-  config: {
+  repositoryConfigs: {
+    repositoryName: string
+    linkResolver: LinkResolver
+    htmlSerializer?: HTMLSerializer
+    transformFieldName?: FieldNameTransformer
     componentResolver: (
       nodes: PrismicNode[],
     ) => React.ComponentType | undefined | null
@@ -36,7 +33,7 @@ function withPrismicUnpublishedPreview(
       nodes: PrismicNode[],
       data: Record<string, unknown>,
     ) => Record<string, unknown>
-  },
+  }[],
 ): React.ComponentType
 ```
 
@@ -45,9 +42,6 @@ function withPrismicUnpublishedPreview(
 
 - **`repositoryConfigs`**<br/>A set of configuration values for each Prismic
   repository used in your app.
-
-- **`config`**<br/>A set of configuration values that determine how the
-  unpublished preview data is prepared and provided.
 
 The following configuration should be provided for each Prismic repository used
 in your app:
@@ -60,7 +54,11 @@ in your app:
   for the configured Prismic repository. This should be the same HTML Serializer
   provided to [`gatsby-source-prismic`][gsp] in your app's `gatsby-config.js`.
 
-Configuration values:
+- **`transformFieldName`**<br/>The optional field name transformer for the
+  configured Prismic repository. This should be the same `transformFieldName`
+  function provided to [`gatsby-source-prismic`][gsp] in your app's
+  `gatsby-config.js` if used. Most projects will not need to provide a value for
+  this option.
 
 - **`componentResolver`**<br/>A function that determines the component to render
   during an unpublished preview. This function will be provided a list of nodes
@@ -122,8 +120,9 @@ import {
   componentResolverFromMap,
 } from 'gatsby-plugin-prismic-previews'
 
-import { PageTemplate } from './PageTemplate'
 import { linkResolver } from '../linkResolver'
+
+import PageTemplate from './PageTemplate'
 
 const NotFoundPage = ({ data }) => {
   const page = data.prismicPage
@@ -135,15 +134,15 @@ const NotFoundPage = ({ data }) => {
   )
 }
 
-export default withPrismicUnpublishedPreview(
-  PageTemplate,
-  { 'my-repository-name': { linkResolver } },
+export default withPrismicUnpublishedPreview(PageTemplate, [
   {
+    repositoryName: 'my-repository-name',
+    linkResolver,
     componentResolver: componentResolverFromMap({
       page: PageTemplate,
     }),
   },
-)
+])
 
 export const query = graphql`
   query NotFoundPage {

--- a/packages/gatsby-plugin-prismic-previews/package.json
+++ b/packages/gatsby-plugin-prismic-previews/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gatsby-plugin-prismic-previews",
-  "version": "4.0.0-alpha.4",
+  "version": "4.0.0-alpha.5",
   "description": "Gatsby plugin for integrating client-side Prismic previews support",
   "license": "MIT",
   "main": "./dist/index.js",

--- a/packages/gatsby-plugin-prismic-previews/src/fieldProxies/sliceFieldProxy.ts
+++ b/packages/gatsby-plugin-prismic-previews/src/fieldProxies/sliceFieldProxy.ts
@@ -8,6 +8,7 @@ import {
   proxyDocumentSubtree,
   ProxyDocumentSubtreeEnv,
 } from '../lib/proxyDocumentSubtree'
+import { mapRecordIndices } from '../lib/mapRecordIndices'
 
 export const valueRefinement = (
   value: unknown,
@@ -20,21 +21,23 @@ export const proxyValue = (
 ): RE.ReaderEither<ProxyDocumentSubtreeEnv, Error, unknown> =>
   pipe(
     RE.ask<ProxyDocumentSubtreeEnv>(),
-    RE.bind('primary', () =>
+    RE.bind('primary', (env) =>
       pipe(
         fieldValue.primary ?? {},
+        mapRecordIndices(env.transformFieldName),
         R.mapWithIndex((fieldName, value) =>
           proxyDocumentSubtree([...path, 'primary', fieldName], value),
         ),
         R.sequence(RE.Applicative),
       ),
     ),
-    RE.bind('items', () =>
+    RE.bind('items', (env) =>
       pipe(
         fieldValue.items ?? [],
         A.map((item) =>
           pipe(
             item,
+            mapRecordIndices(env.transformFieldName),
             R.mapWithIndex((fieldName, value) =>
               proxyDocumentSubtree([...path, 'items', fieldName], value),
             ),

--- a/packages/gatsby-plugin-prismic-previews/src/lib/proxyDocumentSubtree.ts
+++ b/packages/gatsby-plugin-prismic-previews/src/lib/proxyDocumentSubtree.ts
@@ -5,6 +5,7 @@ import { pipe } from 'fp-ts/function'
 import { NodeHelpers } from 'gatsby-node-helpers'
 
 import {
+  FieldNameTransformer,
   HTMLSerializer,
   LinkResolver,
   PluginOptions,
@@ -33,7 +34,7 @@ export interface ProxyDocumentSubtreeEnv {
   imagePlaceholderImgixParams: PluginOptions['imagePlaceholderImgixParams']
   nodeHelpers: NodeHelpers
   createContentDigest(input: string | UnknownRecord): string
-  transformFieldName(fieldName: string): string
+  transformFieldName: FieldNameTransformer
 }
 
 export const proxyDocumentSubtree = (

--- a/packages/gatsby-plugin-prismic-previews/src/types.ts
+++ b/packages/gatsby-plugin-prismic-previews/src/types.ts
@@ -46,3 +46,60 @@ export type UnknownRecord<K extends PropertyKey = PropertyKey> = Record<
   K,
   unknown
 >
+
+export type PrismicRepositoryConfig = {
+  /**
+   * Name of the repository to be configured.
+   */
+  repositoryName: string
+
+  /**
+   * Link Resolver for the repository. This should be the same Link Resolver
+   * provided to `gatsby-source-prismic`'s plugin options.
+   */
+  linkResolver: LinkResolver
+
+  /**
+   * HTML Serializer for the repository. This should be the same HTML Serializer
+   * provided to `gatsby-source-prismic`'s plugin options.
+   */
+  htmlSerializer?: HTMLSerializer
+
+  /**
+   * Field name transformer for the repository. This should be the same function
+   * provided to `gatsby-source-prismic`'s `transformFieldName` plugin option.
+   *
+   * @param fieldName Field name to transform.
+   *
+   * @returns Transformed version of `fieldName`.
+   */
+  transformFieldName?(fieldName: string): string
+
+  /**
+   * Determines the React component to render during an unpublished preview. This
+   * function will be provided a list of nodes whose `url` field (computed using
+   * your app's Link Resolver) matches the page's URL.
+   *
+   * @param nodes List of nodes whose `url` field matches the page's URL.
+   *
+   * @returns The React component to render. If no component is returned, the wrapped component will be rendered.
+   */
+  componentResolver?<P>(
+    nodes: PrismicAPIDocumentNodeInput[],
+  ): React.ComponentType<P> | undefined | null
+
+  /**
+   * Determines the data passed to a Gatsby page during an unpublished preview.
+   * The value returned from this function is passed directly to the `data`
+   * prop.
+   *
+   * @param nodes List of nodes that have URLs resolved to the current page.
+   * @param data The original page's `data` prop.
+   *
+   * @returns The value that will be passed to the page's `data` prop.
+   */
+  dataResolver?<TData extends Record<string, unknown>>(
+    nodes: PrismicAPIDocumentNodeInput[],
+    data: TData,
+  ): Record<string, unknown>
+}

--- a/packages/gatsby-plugin-prismic-previews/src/types.ts
+++ b/packages/gatsby-plugin-prismic-previews/src/types.ts
@@ -3,6 +3,7 @@ import * as gatsbyImgix from 'gatsby-plugin-imgix'
 import * as gatsbyPrismic from 'gatsby-source-prismic'
 import * as prismic from 'ts-prismic'
 import * as PrismicDOM from 'prismic-dom'
+import { SetRequired } from 'type-fest'
 
 export type Mutable<T> = {
   -readonly [P in keyof T]: T[P]
@@ -46,6 +47,15 @@ export type UnknownRecord<K extends PropertyKey = PropertyKey> = Record<
   K,
   unknown
 >
+
+export type PrismicRepositoryConfigs = PrismicRepositoryConfig[]
+
+export type PrismicUnpublishedRepositoryConfig = SetRequired<
+  PrismicRepositoryConfig,
+  'componentResolver'
+>
+
+export type PrismicUnpublishedRepositoryConfigs = PrismicUnpublishedRepositoryConfig[]
 
 export type PrismicRepositoryConfig = {
   /**

--- a/packages/gatsby-plugin-prismic-previews/src/types.ts
+++ b/packages/gatsby-plugin-prismic-previews/src/types.ts
@@ -42,6 +42,7 @@ export interface PrismicAPIDocumentNodeInput<TData = Record<string, unknown>>
 
 export type LinkResolver = (doc: prismic.Document) => string
 export type HTMLSerializer = typeof PrismicDOM.HTMLSerializer
+export type FieldNameTransformer = (fieldName: string) => string
 
 export type UnknownRecord<K extends PropertyKey = PropertyKey> = Record<
   K,
@@ -83,7 +84,7 @@ export type PrismicRepositoryConfig = {
    *
    * @returns Transformed version of `fieldName`.
    */
-  transformFieldName?(fieldName: string): string
+  transformFieldName?: FieldNameTransformer
 
   /**
    * Determines the React component to render during an unpublished preview. This

--- a/packages/gatsby-plugin-prismic-previews/src/usePrismicPreviewBootstrap.ts
+++ b/packages/gatsby-plugin-prismic-previews/src/usePrismicPreviewBootstrap.ts
@@ -21,12 +21,11 @@ import { queryAllDocuments } from './lib/queryAllDocuments'
 import { serializePath } from './lib/serializePath'
 
 import {
-  HTMLSerializer,
-  LinkResolver,
+  Mutable,
   PrismicAPIDocumentNodeInput,
+  PrismicRepositoryConfig,
   TypePathsStore,
   UnknownRecord,
-  Mutable,
 } from './types'
 import { PrismicContextActionType, PrismicContextState } from './context'
 import { usePrismicPreviewContext } from './usePrismicPreviewContext'
@@ -104,7 +103,7 @@ interface UsePrismicPreviewBootstrapProgramEnv {
   createContentDigest(input: string | UnknownRecord): string
 
   pluginOptionsStore: PrismicContextState['pluginOptionsStore']
-  config: UsePrismicPreviewBootstrapConfig
+  repositoryConfigs: PrismicRepositoryConfig[]
 
   // Proxify node env
   getNode(id: string): PrismicAPIDocumentNodeInput | undefined
@@ -145,8 +144,8 @@ const previewBootstrapProgram: RTE.ReaderTaskEither<
 
   RTE.bindW('repositoryConfig', (env) =>
     pipe(
-      env.config,
-      R.lookup(env.repositoryName),
+      env.repositoryConfigs,
+      A.findFirst((config) => config.repositoryName === env.repositoryName),
       RTE.fromOption(
         () =>
           new Error(
@@ -254,45 +253,16 @@ const previewBootstrapProgram: RTE.ReaderTaskEither<
   RTE.map(constVoid),
 )
 
-export type UsePrismicPreviewBootstrapRepositoryConfig = {
-  /**
-   * Link Resolver for the repository. This should be the same Link Resolver
-   * provided to `gatsby-source-prismic`'s plugin options.
-   */
-  linkResolver: LinkResolver
-
-  /**
-   * HTML Serializer for the repository. This should be the same HTML Serializer
-   * provided to `gatsby-source-prismic`'s plugin options.
-   */
-  htmlSerializer?: HTMLSerializer
-
-  /**
-   * Field name transformer for the repository. This should be the same function
-   * provided to `gatsby-source-prismic`'s `transformFieldName` plugin option.
-   *
-   * @param fieldName Field name to transform.
-   *
-   * @returns Transformed version of `fieldName`.
-   */
-  transformFieldName?(fieldName: string): string
-}
-
-export type UsePrismicPreviewBootstrapConfig = Record<
-  string,
-  UsePrismicPreviewBootstrapRepositoryConfig
->
-
 /**
  * React hook that bootstraps a Prismic preview session. When the returned
  * bootstrap function is called, the preiew session will be scoped to this
  * hook's Prismic repository. All documents from the repository will be fetched
  * using the preview session's documents.
  *
- * @param config Configuration that determines how the bootstrap function runs.
+ * @param repositoryConfigs Configuration that determines how the bootstrap function runs.
  */
 export const usePrismicPreviewBootstrap = (
-  config: UsePrismicPreviewBootstrapConfig,
+  repositoryConfigs: PrismicRepositoryConfig[],
 ): readonly [UsePrismicPreviewBootstrapState, UsePrismicPreviewBootstrapFn] => {
   // A ref to the latest contextState is setup specifically for getTypePath
   // which is populated during the program's runtime. Since
@@ -351,7 +321,7 @@ export const usePrismicPreviewBootstrap = (
           }),
         isBootstrapped: contextState.isBootstrapped,
         pluginOptionsStore: contextState.pluginOptionsStore,
-        config,
+        repositoryConfigs,
         // We use the ref to ensure we can access nodes populated during the
         // same run that the population occurs. This means we don't need to wait
         // for the next render to access nodes.
@@ -379,7 +349,7 @@ export const usePrismicPreviewBootstrap = (
       ),
     )()
   }, [
-    config,
+    repositoryConfigs,
     contextState.pluginOptionsStore,
     contextState.isBootstrapped,
     contextDispatch,

--- a/packages/gatsby-plugin-prismic-previews/src/usePrismicPreviewBootstrap.ts
+++ b/packages/gatsby-plugin-prismic-previews/src/usePrismicPreviewBootstrap.ts
@@ -23,7 +23,7 @@ import { serializePath } from './lib/serializePath'
 import {
   Mutable,
   PrismicAPIDocumentNodeInput,
-  PrismicRepositoryConfig,
+  PrismicRepositoryConfigs,
   TypePathsStore,
   UnknownRecord,
 } from './types'
@@ -103,7 +103,7 @@ interface UsePrismicPreviewBootstrapProgramEnv {
   createContentDigest(input: string | UnknownRecord): string
 
   pluginOptionsStore: PrismicContextState['pluginOptionsStore']
-  repositoryConfigs: PrismicRepositoryConfig[]
+  repositoryConfigs: PrismicRepositoryConfigs
 
   // Proxify node env
   getNode(id: string): PrismicAPIDocumentNodeInput | undefined
@@ -262,7 +262,7 @@ const previewBootstrapProgram: RTE.ReaderTaskEither<
  * @param repositoryConfigs Configuration that determines how the bootstrap function runs.
  */
 export const usePrismicPreviewBootstrap = (
-  repositoryConfigs: PrismicRepositoryConfig[],
+  repositoryConfigs: PrismicRepositoryConfigs,
 ): readonly [UsePrismicPreviewBootstrapState, UsePrismicPreviewBootstrapFn] => {
   // A ref to the latest contextState is setup specifically for getTypePath
   // which is populated during the program's runtime. Since

--- a/packages/gatsby-plugin-prismic-previews/src/usePrismicPreviewResolver.ts
+++ b/packages/gatsby-plugin-prismic-previews/src/usePrismicPreviewResolver.ts
@@ -15,7 +15,7 @@ import { getCookie } from './lib/getCookie'
 import { getURLSearchParam } from './lib/getURLSearchParam'
 import { isPreviewResolverSession } from './lib/isPreviewResolverSession'
 
-import { LinkResolver, PrismicRepositoryConfig } from './types'
+import { LinkResolver, PrismicRepositoryConfigs } from './types'
 import { usePrismicPreviewContext } from './usePrismicPreviewContext'
 import { PrismicContextActionType, PrismicContextState } from './context'
 
@@ -86,7 +86,7 @@ interface UsePrismicPreviewResolverProgramEnv {
   beginResolving: IO.IO<void>
   resolved(path: string): IO.IO<void>
   pluginOptionsStore: PrismicContextState['pluginOptionsStore']
-  repositoryConfigs: PrismicRepositoryConfig[]
+  repositoryConfigs: PrismicRepositoryConfigs
 }
 
 const previewResolverProgram: RTE.ReaderTaskEither<
@@ -210,7 +210,7 @@ export type UsePrismicPreviewResolverRepositoryConfig = {
  * @param repositoryConfigs Configuration that determines how the destination URL is resolved.
  */
 export const usePrismicPreviewResolver = (
-  repositoryConfigs: PrismicRepositoryConfig[],
+  repositoryConfigs: PrismicRepositoryConfigs,
 ): readonly [UsePrismicPreviewResolverState, UsePrismicPreviewResolverFn] => {
   const [contextState, contextDispatch] = usePrismicPreviewContext()
   const [localState, localDispatch] = React.useReducer(

--- a/packages/gatsby-plugin-prismic-previews/src/withPrismicPreview.tsx
+++ b/packages/gatsby-plugin-prismic-previews/src/withPrismicPreview.tsx
@@ -8,7 +8,7 @@ import { getComponentDisplayName } from './lib/getComponentDisplayName'
 import { isPreviewSession } from './lib/isPreviewSession'
 import { userFriendlyError } from './lib/userFriendlyError'
 
-import { PrismicRepositoryConfig, UnknownRecord } from './types'
+import { PrismicRepositoryConfigs, UnknownRecord } from './types'
 import {
   usePrismicPreviewBootstrap,
   UsePrismicPreviewBootstrapFn,
@@ -61,7 +61,7 @@ export const withPrismicPreview = <
   WrappedComponent: React.ComponentType<
     TProps & WithPrismicPreviewProps<TStaticData>
   >,
-  repositoryConfigs: PrismicRepositoryConfig[],
+  repositoryConfigs: PrismicRepositoryConfigs,
   config: WithPrismicPreviewConfig = {},
 ): React.ComponentType<TProps> => {
   const WithPrismicPreview = (props: TProps): React.ReactElement => {

--- a/packages/gatsby-plugin-prismic-previews/src/withPrismicPreview.tsx
+++ b/packages/gatsby-plugin-prismic-previews/src/withPrismicPreview.tsx
@@ -8,10 +8,9 @@ import { getComponentDisplayName } from './lib/getComponentDisplayName'
 import { isPreviewSession } from './lib/isPreviewSession'
 import { userFriendlyError } from './lib/userFriendlyError'
 
-import { UnknownRecord } from './types'
+import { PrismicRepositoryConfig, UnknownRecord } from './types'
 import {
   usePrismicPreviewBootstrap,
-  UsePrismicPreviewBootstrapConfig,
   UsePrismicPreviewBootstrapFn,
   UsePrismicPreviewBootstrapState,
 } from './usePrismicPreviewBootstrap'
@@ -62,13 +61,13 @@ export const withPrismicPreview = <
   WrappedComponent: React.ComponentType<
     TProps & WithPrismicPreviewProps<TStaticData>
   >,
-  usePrismicPreviewBootstrapConfig: UsePrismicPreviewBootstrapConfig,
+  repositoryConfigs: PrismicRepositoryConfig[],
   config: WithPrismicPreviewConfig = {},
 ): React.ComponentType<TProps> => {
   const WithPrismicPreview = (props: TProps): React.ReactElement => {
     const [contextState] = usePrismicPreviewContext()
     const [bootstrapState, bootstrapPreview] = usePrismicPreviewBootstrap(
-      usePrismicPreviewBootstrapConfig,
+      repositoryConfigs,
     )
     const [accessToken, { set: setAccessToken }] = usePrismicPreviewAccessToken(
       contextState.activeRepositoryName,

--- a/packages/gatsby-plugin-prismic-previews/src/withPrismicPreviewResolver.tsx
+++ b/packages/gatsby-plugin-prismic-previews/src/withPrismicPreviewResolver.tsx
@@ -8,6 +8,7 @@ import { getComponentDisplayName } from './lib/getComponentDisplayName'
 import { isPreviewResolverSession } from './lib/isPreviewResolverSession'
 import { userFriendlyError } from './lib/userFriendlyError'
 
+import { PrismicRepositoryConfigs } from './types'
 import {
   usePrismicPreviewResolver,
   UsePrismicPreviewResolverFn,
@@ -23,7 +24,6 @@ import { Root } from './components/Root'
 import { ModalAccessToken } from './components/ModalAccessToken'
 import { ModalError } from './components/ModalError'
 import { ModalLoading } from './components/ModalLoading'
-import { PrismicRepositoryConfig } from './types'
 
 export interface WithPrismicPreviewResolverProps {
   isPrismicPreview: boolean | null
@@ -61,7 +61,7 @@ export const withPrismicPreviewResolver = <TProps extends gatsby.PageProps>(
   WrappedComponent: React.ComponentType<
     TProps & WithPrismicPreviewResolverProps
   >,
-  repositoryConfigs: PrismicRepositoryConfig[],
+  repositoryConfigs: PrismicRepositoryConfigs,
   config: WithPrismicPreviewResolverConfig = {},
 ): React.ComponentType<TProps> => {
   const WithPrismicPreviewResolver = (props: TProps): React.ReactElement => {

--- a/packages/gatsby-plugin-prismic-previews/src/withPrismicPreviewResolver.tsx
+++ b/packages/gatsby-plugin-prismic-previews/src/withPrismicPreviewResolver.tsx
@@ -10,7 +10,6 @@ import { userFriendlyError } from './lib/userFriendlyError'
 
 import {
   usePrismicPreviewResolver,
-  UsePrismicPreviewResolverConfig,
   UsePrismicPreviewResolverFn,
   UsePrismicPreviewResolverState,
 } from './usePrismicPreviewResolver'
@@ -24,6 +23,7 @@ import { Root } from './components/Root'
 import { ModalAccessToken } from './components/ModalAccessToken'
 import { ModalError } from './components/ModalError'
 import { ModalLoading } from './components/ModalLoading'
+import { PrismicRepositoryConfig } from './types'
 
 export interface WithPrismicPreviewResolverProps {
   isPrismicPreview: boolean | null
@@ -61,13 +61,13 @@ export const withPrismicPreviewResolver = <TProps extends gatsby.PageProps>(
   WrappedComponent: React.ComponentType<
     TProps & WithPrismicPreviewResolverProps
   >,
-  usePrismicPreviewResolverConfig: UsePrismicPreviewResolverConfig,
+  repositoryConfigs: PrismicRepositoryConfig[],
   config: WithPrismicPreviewResolverConfig = {},
 ): React.ComponentType<TProps> => {
   const WithPrismicPreviewResolver = (props: TProps): React.ReactElement => {
     const [contextState] = usePrismicPreviewContext()
     const [resolverState, resolvePreview] = usePrismicPreviewResolver(
-      usePrismicPreviewResolverConfig,
+      repositoryConfigs,
     )
     const [accessToken, { set: setAccessToken }] = usePrismicPreviewAccessToken(
       contextState.activeRepositoryName,

--- a/packages/gatsby-plugin-prismic-previews/src/withPrismicUnpublishedPreview.tsx
+++ b/packages/gatsby-plugin-prismic-previews/src/withPrismicUnpublishedPreview.tsx
@@ -13,7 +13,11 @@ import { getNodesForPath } from './lib/getNodesForPath'
 import { isPreviewSession } from './lib/isPreviewSession'
 import { userFriendlyError } from './lib/userFriendlyError'
 
-import { PrismicRepositoryConfig, UnknownRecord } from './types'
+import {
+  PrismicRepositoryConfig,
+  PrismicUnpublishedRepositoryConfigs,
+  UnknownRecord,
+} from './types'
 import { usePrismicPreviewBootstrap } from './usePrismicPreviewBootstrap'
 import { usePrismicPreviewContext } from './usePrismicPreviewContext'
 import { usePrismicPreviewAccessToken } from './usePrismicPreviewAccessToken'
@@ -22,7 +26,6 @@ import { Root } from './components/Root'
 import { ModalAccessToken } from './components/ModalAccessToken'
 import { ModalError } from './components/ModalError'
 import { ModalLoading } from './components/ModalLoading'
-import { SetRequired } from 'type-fest'
 
 /**
  * A convenience function to create a `componentResolver` function from a record
@@ -76,11 +79,6 @@ type LocalState =
   | 'DISPLAY_ERROR'
   | 'NOT_PREVIEW'
 
-export type PrismicUnpublishedRepositoryConfig = SetRequired<
-  PrismicRepositoryConfig,
-  'componentResolver'
->
-
 /**
  * A React higher order component (HOC) that wraps a Gatsby page to
  * automatically display a template for an unpublished Prismic document. This
@@ -97,7 +95,7 @@ export const withPrismicUnpublishedPreview = <
   TProps extends gatsby.PageProps<TStaticData>
 >(
   WrappedComponent: React.ComponentType<TProps>,
-  repositoryConfigs: PrismicUnpublishedRepositoryConfig[],
+  repositoryConfigs: PrismicUnpublishedRepositoryConfigs,
 ): React.ComponentType<TProps> => {
   const WithPrismicUnpublishedPreview = (props: TProps): React.ReactElement => {
     const [contextState] = usePrismicPreviewContext()

--- a/packages/gatsby-plugin-prismic-previews/test/useMergePrismicPreviewData.test.ts
+++ b/packages/gatsby-plugin-prismic-previews/test/useMergePrismicPreviewData.test.ts
@@ -21,11 +21,11 @@ import { polyfillKy } from './__testutils__/polyfillKy'
 import {
   PrismicAPIDocumentNodeInput,
   PrismicPreviewProvider,
-  UsePrismicPreviewBootstrapConfig,
   useMergePrismicPreviewData,
   usePrismicPreviewBootstrap,
   usePrismicPreviewContext,
   PluginOptions,
+  PrismicRepositoryConfig,
 } from '../src'
 import { onClientEntry } from '../src/gatsby-browser'
 
@@ -38,13 +38,14 @@ const createStaticData = () => {
   return { previewable, nonPreviewable }
 }
 
-const createConfig = (
+const createRepositoryConfigs = (
   pluginOptions: PluginOptions,
-): UsePrismicPreviewBootstrapConfig => ({
-  [pluginOptions.repositoryName]: {
+): PrismicRepositoryConfig[] => [
+  {
+    repositoryName: pluginOptions.repositoryName,
     linkResolver: (doc): string => `/${doc.uid}`,
   },
-})
+]
 
 const nodeHelpers = createNodeHelpers({
   typePrefix: 'Prismic prefix',
@@ -87,7 +88,7 @@ test.serial(
   async (t) => {
     const pluginOptions = createPluginOptions(t)
     const gatsbyContext = createGatsbyContext()
-    const config = createConfig(pluginOptions)
+    const config = createRepositoryConfigs(pluginOptions)
     const queryResponse = createPrismicAPIQueryResponse()
 
     const ref = createPreviewRef(pluginOptions.repositoryName)

--- a/packages/gatsby-plugin-prismic-previews/test/useMergePrismicPreviewData.test.ts
+++ b/packages/gatsby-plugin-prismic-previews/test/useMergePrismicPreviewData.test.ts
@@ -25,7 +25,7 @@ import {
   usePrismicPreviewBootstrap,
   usePrismicPreviewContext,
   PluginOptions,
-  PrismicRepositoryConfig,
+  PrismicRepositoryConfigs,
 } from '../src'
 import { onClientEntry } from '../src/gatsby-browser'
 
@@ -40,7 +40,7 @@ const createStaticData = () => {
 
 const createRepositoryConfigs = (
   pluginOptions: PluginOptions,
-): PrismicRepositoryConfig[] => [
+): PrismicRepositoryConfigs => [
   {
     repositoryName: pluginOptions.repositoryName,
     linkResolver: (doc): string => `/${doc.uid}`,

--- a/packages/gatsby-plugin-prismic-previews/test/usePrismicPreviewBootstrap-field-proxies.test.ts
+++ b/packages/gatsby-plugin-prismic-previews/test/usePrismicPreviewBootstrap-field-proxies.test.ts
@@ -21,7 +21,7 @@ import { polyfillKy } from './__testutils__/polyfillKy'
 import {
   PluginOptions,
   PrismicPreviewProvider,
-  PrismicRepositoryConfig,
+  PrismicRepositoryConfigs,
   usePrismicPreviewBootstrap,
   usePrismicPreviewContext,
 } from '../src'
@@ -29,7 +29,7 @@ import { onClientEntry } from '../src/gatsby-browser'
 
 const createRepositoryConfigs = (
   pluginOptions: PluginOptions,
-): PrismicRepositoryConfig[] => [
+): PrismicRepositoryConfigs => [
   {
     repositoryName: pluginOptions.repositoryName,
     linkResolver: (doc): string => `/${doc.uid}`,
@@ -56,7 +56,7 @@ const performPreview = async (
   t: ExecutionContext,
   gatsbyContext: gatsby.BrowserPluginArgs,
   pluginOptions: PluginOptions,
-  repositoryConfigs: PrismicRepositoryConfig[],
+  repositoryConfigs: PrismicRepositoryConfigs,
   queryResponse: prismic.Response.Query,
   typePathsFilename: string,
   typePaths: Record<string, gatsbyPrismic.PrismicTypePathType>,

--- a/packages/gatsby-plugin-prismic-previews/test/usePrismicPreviewBootstrap.test.ts
+++ b/packages/gatsby-plugin-prismic-previews/test/usePrismicPreviewBootstrap.test.ts
@@ -24,13 +24,13 @@ import {
   usePrismicPreviewBootstrap,
   usePrismicPreviewContext,
   PluginOptions,
-  PrismicRepositoryConfig,
+  PrismicRepositoryConfigs,
 } from '../src'
 import { onClientEntry } from '../src/gatsby-browser'
 
 const createRepositoryConfigs = (
   pluginOptions: PluginOptions,
-): PrismicRepositoryConfig[] => [
+): PrismicRepositoryConfigs => [
   {
     repositoryName: pluginOptions.repositoryName,
     linkResolver: (doc): string => `/${doc.uid}`,

--- a/packages/gatsby-plugin-prismic-previews/test/usePrismicPreviewBootstrap.test.ts
+++ b/packages/gatsby-plugin-prismic-previews/test/usePrismicPreviewBootstrap.test.ts
@@ -21,20 +21,21 @@ import { resolveURL } from './__testutils__/resolveURL'
 import {
   PrismicAPIDocumentNodeInput,
   PrismicPreviewProvider,
-  UsePrismicPreviewBootstrapConfig,
   usePrismicPreviewBootstrap,
   usePrismicPreviewContext,
   PluginOptions,
+  PrismicRepositoryConfig,
 } from '../src'
 import { onClientEntry } from '../src/gatsby-browser'
 
-const createConfig = (
+const createRepositoryConfigs = (
   pluginOptions: PluginOptions,
-): UsePrismicPreviewBootstrapConfig => ({
-  [pluginOptions.repositoryName]: {
+): PrismicRepositoryConfig[] => [
+  {
+    repositoryName: pluginOptions.repositoryName,
     linkResolver: (doc): string => `/${doc.uid}`,
   },
-})
+]
 
 const nodeHelpers = createNodeHelpers({
   typePrefix: 'Prismic prefix',
@@ -60,7 +61,7 @@ test.after(() => {
 test.serial('initial state', async (t) => {
   const gatsbyContext = createGatsbyContext()
   const pluginOptions = createPluginOptions(t)
-  const config = createConfig(pluginOptions)
+  const config = createRepositoryConfigs(pluginOptions)
 
   // @ts-expect-error - Partial gatsbyContext provided
   await onClientEntry(gatsbyContext, pluginOptions)
@@ -76,7 +77,7 @@ test.serial('initial state', async (t) => {
 test.serial('fails if not a preview session - cookie is not set', async (t) => {
   const gatsbyContext = createGatsbyContext()
   const pluginOptions = createPluginOptions(t)
-  const config = createConfig(pluginOptions)
+  const config = createRepositoryConfigs(pluginOptions)
 
   // @ts-expect-error - Partial gatsbyContext provided
   await onClientEntry(gatsbyContext, pluginOptions)
@@ -105,7 +106,7 @@ test.serial(
   async (t) => {
     const gatsbyContext = createGatsbyContext()
     const pluginOptions = createPluginOptions(t)
-    const config = createConfig(pluginOptions)
+    const config = createRepositoryConfigs(pluginOptions)
     const queryResponsePage1 = createPrismicAPIQueryResponse(undefined, {
       page: 1,
       total_pages: 2,
@@ -125,7 +126,7 @@ test.serial(
 
       return {
         ...node,
-        url: config[pluginOptions.repositoryName].linkResolver(doc),
+        url: config[0].linkResolver(doc),
       }
     })
 
@@ -136,7 +137,7 @@ test.serial(
 
       return {
         ...node,
-        url: config[pluginOptions.repositoryName].linkResolver(doc),
+        url: config[0].linkResolver(doc),
       }
     })
 
@@ -217,7 +218,7 @@ test.serial(
 test.serial('fails if already bootstrapped', async (t) => {
   const gatsbyContext = createGatsbyContext()
   const pluginOptions = createPluginOptions(t)
-  const config = createConfig(pluginOptions)
+  const config = createRepositoryConfigs(pluginOptions)
   const queryResponsePage1 = createPrismicAPIQueryResponse(undefined, {
     page: 1,
     total_pages: 2,

--- a/packages/gatsby-plugin-prismic-previews/test/usePrismicPreviewResolver.test.ts
+++ b/packages/gatsby-plugin-prismic-previews/test/usePrismicPreviewResolver.test.ts
@@ -18,18 +18,20 @@ import { polyfillKy } from './__testutils__/polyfillKy'
 import {
   PluginOptions,
   PrismicPreviewProvider,
-  UsePrismicPreviewResolverConfig,
   usePrismicPreviewResolver,
+  PrismicRepositoryConfig,
 } from '../src'
 import { onClientEntry } from '../src/gatsby-browser'
 
 const createConfig = (
   pluginOptions: PluginOptions,
-): UsePrismicPreviewResolverConfig => ({
-  [pluginOptions.repositoryName]: {
+): PrismicRepositoryConfig[] => [
+  {
+    repositoryName: pluginOptions.repositoryName,
     linkResolver: (doc): string => `/${doc.uid}`,
+    componentResolver: () => null,
   },
-})
+]
 
 const server = mswNode.setupServer()
 test.before(() => {

--- a/packages/gatsby-plugin-prismic-previews/test/usePrismicPreviewResolver.test.ts
+++ b/packages/gatsby-plugin-prismic-previews/test/usePrismicPreviewResolver.test.ts
@@ -19,13 +19,13 @@ import {
   PluginOptions,
   PrismicPreviewProvider,
   usePrismicPreviewResolver,
-  PrismicRepositoryConfig,
+  PrismicRepositoryConfigs,
 } from '../src'
 import { onClientEntry } from '../src/gatsby-browser'
 
 const createConfig = (
   pluginOptions: PluginOptions,
-): PrismicRepositoryConfig[] => [
+): PrismicRepositoryConfigs => [
   {
     repositoryName: pluginOptions.repositoryName,
     linkResolver: (doc): string => `/${doc.uid}`,

--- a/packages/gatsby-plugin-prismic-previews/test/withPrismicPreview.test.tsx
+++ b/packages/gatsby-plugin-prismic-previews/test/withPrismicPreview.test.tsx
@@ -27,10 +27,10 @@ import {
   PrismicAPIDocumentNodeInput,
   PrismicPreviewProvider,
   UnknownRecord,
-  UsePrismicPreviewBootstrapConfig,
   WithPrismicPreviewConfig,
   WithPrismicPreviewProps,
   withPrismicPreview,
+  PrismicRepositoryConfig,
 } from '../src'
 import { onClientEntry } from '../src/on-client-entry'
 
@@ -61,13 +61,14 @@ test.after(() => {
   server.close()
 })
 
-const createUsePrismicPreviewBootstrapConfig = (
+const createRepositoryConfigs = (
   pluginOptions: PluginOptions,
-): UsePrismicPreviewBootstrapConfig => ({
-  [pluginOptions.repositoryName]: {
+): PrismicRepositoryConfig[] => [
+  {
+    repositoryName: pluginOptions.repositoryName,
     linkResolver: (doc): string => `/${doc.uid}`,
   },
-})
+]
 
 const Page = <TProps extends UnknownRecord = UnknownRecord>(
   props: gatsby.PageProps<TProps> & WithPrismicPreviewProps<TProps>,
@@ -91,14 +92,10 @@ const Page = <TProps extends UnknownRecord = UnknownRecord>(
 
 const createTree = (
   pageProps: gatsby.PageProps,
-  usePrismicPreviewBootstrapConfig: UsePrismicPreviewBootstrapConfig,
+  repositoryConfigs: PrismicRepositoryConfig[],
   config?: WithPrismicPreviewConfig,
 ) => {
-  const WrappedPage = withPrismicPreview(
-    Page,
-    usePrismicPreviewBootstrapConfig,
-    config,
-  )
+  const WrappedPage = withPrismicPreview(Page, repositoryConfigs, config)
 
   return (
     <PrismicPreviewProvider>
@@ -134,7 +131,7 @@ test.serial(
     staticData.previewable.uid = 'old'
 
     const pageProps = createPageProps(staticData)
-    const config = createUsePrismicPreviewBootstrapConfig(pluginOptions)
+    const config = createRepositoryConfigs(pluginOptions)
     const tree = createTree(pageProps, config)
 
     // @ts-expect-error - Partial gatsbyContext provided
@@ -184,7 +181,7 @@ test.serial('merges data if preview data is available', async (t) => {
   staticData.previewable.uid = 'old'
 
   const pageProps = createPageProps(staticData)
-  const config = createUsePrismicPreviewBootstrapConfig(pluginOptions)
+  const config = createRepositoryConfigs(pluginOptions)
   const tree = createTree(pageProps, config)
 
   // @ts-expect-error - Partial gatsbyContext provided

--- a/packages/gatsby-plugin-prismic-previews/test/withPrismicPreview.test.tsx
+++ b/packages/gatsby-plugin-prismic-previews/test/withPrismicPreview.test.tsx
@@ -26,11 +26,11 @@ import {
   PluginOptions,
   PrismicAPIDocumentNodeInput,
   PrismicPreviewProvider,
+  PrismicRepositoryConfigs,
   UnknownRecord,
   WithPrismicPreviewConfig,
   WithPrismicPreviewProps,
   withPrismicPreview,
-  PrismicRepositoryConfig,
 } from '../src'
 import { onClientEntry } from '../src/on-client-entry'
 
@@ -63,7 +63,7 @@ test.after(() => {
 
 const createRepositoryConfigs = (
   pluginOptions: PluginOptions,
-): PrismicRepositoryConfig[] => [
+): PrismicRepositoryConfigs => [
   {
     repositoryName: pluginOptions.repositoryName,
     linkResolver: (doc): string => `/${doc.uid}`,
@@ -92,7 +92,7 @@ const Page = <TProps extends UnknownRecord = UnknownRecord>(
 
 const createTree = (
   pageProps: gatsby.PageProps,
-  repositoryConfigs: PrismicRepositoryConfig[],
+  repositoryConfigs: PrismicRepositoryConfigs,
   config?: WithPrismicPreviewConfig,
 ) => {
   const WrappedPage = withPrismicPreview(Page, repositoryConfigs, config)

--- a/packages/gatsby-plugin-prismic-previews/test/withPrismicPreviewResolver.test.tsx
+++ b/packages/gatsby-plugin-prismic-previews/test/withPrismicPreviewResolver.test.tsx
@@ -26,7 +26,7 @@ import {
   WithPrismicPreviewResolverConfig,
   WithPrismicPreviewResolverProps,
   withPrismicPreviewResolver,
-  UsePrismicPreviewBootstrapConfig,
+  PrismicRepositoryConfig,
 } from '../src'
 import { onClientEntry } from '../src/on-client-entry'
 import { navigateToPreviewResolverURL } from './__testutils__/navigateToPreviewResolverURL'
@@ -50,13 +50,14 @@ test.after(() => {
   server.close()
 })
 
-const createUsePrismicPreviewResolverConfig = (
+const createRepositoryConfigs = (
   pluginOptions: PluginOptions,
-): UsePrismicPreviewBootstrapConfig => ({
-  [pluginOptions.repositoryName]: {
+): PrismicRepositoryConfig[] => [
+  {
+    repositoryName: pluginOptions.repositoryName,
     linkResolver: (doc): string => `/${doc.uid}`,
   },
-})
+]
 
 const createConfig = (): WithPrismicPreviewResolverConfig => ({
   navigate: sinon.stub().returns(void 0),
@@ -75,12 +76,12 @@ const Page = (props: gatsby.PageProps & WithPrismicPreviewResolverProps) => (
 
 const createTree = (
   pageProps: gatsby.PageProps,
-  usePrismicPreviewResolverConfig: UsePrismicPreviewBootstrapConfig,
+  repositoryConfigs: PrismicRepositoryConfig[],
   config?: WithPrismicPreviewResolverConfig,
 ) => {
   const WrappedPage = withPrismicPreviewResolver(
     Page,
-    usePrismicPreviewResolverConfig,
+    repositoryConfigs,
     config,
   )
 
@@ -95,7 +96,7 @@ test.serial('renders component if not a preview', async (t) => {
   const gatsbyContext = createGatsbyContext()
   const pluginOptions = createPluginOptions(t)
   const pageProps = createPageProps()
-  const hookConfig = createUsePrismicPreviewResolverConfig(pluginOptions)
+  const hookConfig = createRepositoryConfigs(pluginOptions)
   const config = createConfig()
   const tree = createTree(pageProps, hookConfig, config)
 
@@ -111,7 +112,7 @@ test.serial('not a preview if documentId is not in URL', async (t) => {
   const gatsbyContext = createGatsbyContext()
   const pluginOptions = createPluginOptions(t)
   const pageProps = createPageProps()
-  const hookConfig = createUsePrismicPreviewResolverConfig(pluginOptions)
+  const hookConfig = createRepositoryConfigs(pluginOptions)
   const config = createConfig()
   const tree = createTree(pageProps, hookConfig, config)
   const token = createPreviewRef(pluginOptions.repositoryName)
@@ -132,7 +133,7 @@ test.serial('not a preview if no token is available', async (t) => {
   const gatsbyContext = createGatsbyContext()
   const pluginOptions = createPluginOptions(t)
   const pageProps = createPageProps()
-  const hookConfig = createUsePrismicPreviewResolverConfig(pluginOptions)
+  const hookConfig = createRepositoryConfigs(pluginOptions)
   const config = createConfig()
   const tree = createTree(pageProps, hookConfig, config)
   const token = createPreviewRef(pluginOptions.repositoryName)
@@ -152,7 +153,7 @@ test.serial('redirects to path on valid preview', async (t) => {
   const gatsbyContext = createGatsbyContext()
   const pluginOptions = createPluginOptions(t)
   const pageProps = createPageProps()
-  const hookConfig = createUsePrismicPreviewResolverConfig(pluginOptions)
+  const hookConfig = createRepositoryConfigs(pluginOptions)
   const config = createConfig()
   const tree = createTree(pageProps, hookConfig, config)
   const ref = createPreviewRef(pluginOptions.repositoryName)
@@ -183,7 +184,7 @@ test.serial('redirects to path on valid preview', async (t) => {
 
   t.true(
     (config.navigate as sinon.SinonStub).calledWith(
-      hookConfig[pluginOptions.repositoryName].linkResolver(doc),
+      hookConfig[0].linkResolver(doc),
     ),
   )
 })
@@ -194,7 +195,7 @@ test.serial(
     const gatsbyContext = createGatsbyContext()
     const pluginOptions = createPluginOptions(t)
     const pageProps = createPageProps()
-    const hookConfig = createUsePrismicPreviewResolverConfig(pluginOptions)
+    const hookConfig = createRepositoryConfigs(pluginOptions)
     const config = createConfig()
     config.autoRedirect = false
     const tree = createTree(pageProps, hookConfig, config)
@@ -226,7 +227,7 @@ test.serial(
 
     t.true(
       result.getByTestId('prismicPreviewPath').textContent ===
-        hookConfig[pluginOptions.repositoryName].linkResolver(doc),
+        hookConfig[0].linkResolver(doc),
     )
     t.true((config.navigate as sinon.SinonStub).notCalled)
   },

--- a/packages/gatsby-plugin-prismic-previews/test/withPrismicPreviewResolver.test.tsx
+++ b/packages/gatsby-plugin-prismic-previews/test/withPrismicPreviewResolver.test.tsx
@@ -26,7 +26,7 @@ import {
   WithPrismicPreviewResolverConfig,
   WithPrismicPreviewResolverProps,
   withPrismicPreviewResolver,
-  PrismicRepositoryConfig,
+  PrismicRepositoryConfigs,
 } from '../src'
 import { onClientEntry } from '../src/on-client-entry'
 import { navigateToPreviewResolverURL } from './__testutils__/navigateToPreviewResolverURL'
@@ -52,7 +52,7 @@ test.after(() => {
 
 const createRepositoryConfigs = (
   pluginOptions: PluginOptions,
-): PrismicRepositoryConfig[] => [
+): PrismicRepositoryConfigs => [
   {
     repositoryName: pluginOptions.repositoryName,
     linkResolver: (doc): string => `/${doc.uid}`,
@@ -76,7 +76,7 @@ const Page = (props: gatsby.PageProps & WithPrismicPreviewResolverProps) => (
 
 const createTree = (
   pageProps: gatsby.PageProps,
-  repositoryConfigs: PrismicRepositoryConfig[],
+  repositoryConfigs: PrismicRepositoryConfigs,
   config?: WithPrismicPreviewResolverConfig,
 ) => {
   const WrappedPage = withPrismicPreviewResolver(

--- a/packages/gatsby-plugin-prismic-previews/test/withPrismicUnpublishedPreview.test.tsx
+++ b/packages/gatsby-plugin-prismic-previews/test/withPrismicUnpublishedPreview.test.tsx
@@ -27,12 +27,12 @@ import {
   PrismicAPIDocumentNodeInput,
   PrismicPreviewProvider,
   UnknownRecord,
-  UsePrismicPreviewBootstrapConfig,
   WithPrismicPreviewProps,
-  WithPrismicUnpublishedPreviewConfig,
   componentResolverFromMap,
   withPrismicPreview,
   withPrismicUnpublishedPreview,
+  PrismicRepositoryConfig,
+  PrismicUnpublishedRepositoryConfig,
 } from '../src'
 import { onClientEntry } from '../src/on-client-entry'
 import { createPrismicAPIDocumentNodeInput } from './__testutils__/createPrismicAPIDocumentNodeInput'
@@ -65,21 +65,23 @@ test.after(() => {
   server.close()
 })
 
-const createUsePrismicPreviewBootstrapConfig = (
+const createRepositoryConfigs = (
   pluginOptions: PluginOptions,
-): UsePrismicPreviewBootstrapConfig => ({
-  [pluginOptions.repositoryName]: {
-    linkResolver: (doc): string => `/${doc.uid}`,
-  },
-})
+): PrismicUnpublishedRepositoryConfig[] => {
+  const baseConfigs: PrismicRepositoryConfig[] = [
+    {
+      repositoryName: pluginOptions.repositoryName,
+      linkResolver: (doc): string => `/${doc.uid}`,
+    },
+  ]
 
-const createWithPrismicUnpublishedPreviewConfig = (
-  usePrismicPreviewBootstrapConfig: UsePrismicPreviewBootstrapConfig,
-): WithPrismicUnpublishedPreviewConfig => ({
-  componentResolver: componentResolverFromMap({
-    type: withPrismicPreview(Page, usePrismicPreviewBootstrapConfig),
-  }),
-})
+  return baseConfigs.map((config) => ({
+    ...config,
+    componentResolver: componentResolverFromMap({
+      type: withPrismicPreview(Page, baseConfigs),
+    }),
+  }))
+}
 
 const NotFoundPage = <TProps extends UnknownRecord = UnknownRecord>(
   props: gatsby.PageProps<TProps>,
@@ -113,13 +115,11 @@ const Page = <TProps extends UnknownRecord = UnknownRecord>(
 
 const createTree = (
   pageProps: gatsby.PageProps,
-  usePrismicPreviewBootstrapConfig: UsePrismicPreviewBootstrapConfig,
-  config: WithPrismicUnpublishedPreviewConfig,
+  repositoryConfigs: PrismicUnpublishedRepositoryConfig[],
 ) => {
   const WrappedPage = withPrismicUnpublishedPreview(
     NotFoundPage,
-    usePrismicPreviewBootstrapConfig,
-    config,
+    repositoryConfigs,
   )
 
   return (
@@ -154,9 +154,8 @@ test.serial('renders the 404 page if not a preview', async (t) => {
   staticData.previewable.uid = 'old'
 
   const pageProps = createPageProps(staticData)
-  const bootstrapConfig = createUsePrismicPreviewBootstrapConfig(pluginOptions)
-  const config = createWithPrismicUnpublishedPreviewConfig(bootstrapConfig)
-  const tree = createTree(pageProps, bootstrapConfig, config)
+  const repositoryConfigs = createRepositoryConfigs(pluginOptions)
+  const tree = createTree(pageProps, repositoryConfigs)
 
   // @ts-expect-error - Partial gatsbyContext provided
   await onClientEntry(gatsbyContext, pluginOptions)
@@ -208,9 +207,8 @@ test.serial('merges data if preview data is available', async (t) => {
   staticData.previewable.uid = 'old'
 
   const pageProps = createPageProps(staticData)
-  const bootstrapConfig = createUsePrismicPreviewBootstrapConfig(pluginOptions)
-  const config = createWithPrismicUnpublishedPreviewConfig(bootstrapConfig)
-  const tree = createTree(pageProps, bootstrapConfig, config)
+  const repositoryConfigs = createRepositoryConfigs(pluginOptions)
+  const tree = createTree(pageProps, repositoryConfigs)
 
   // @ts-expect-error - Partial gatsbyContext provided
   await onClientEntry(gatsbyContext, pluginOptions)

--- a/packages/gatsby-plugin-prismic-previews/test/withPrismicUnpublishedPreview.test.tsx
+++ b/packages/gatsby-plugin-prismic-previews/test/withPrismicUnpublishedPreview.test.tsx
@@ -26,13 +26,13 @@ import {
   PluginOptions,
   PrismicAPIDocumentNodeInput,
   PrismicPreviewProvider,
+  PrismicRepositoryConfigs,
+  PrismicUnpublishedRepositoryConfigs,
   UnknownRecord,
   WithPrismicPreviewProps,
   componentResolverFromMap,
   withPrismicPreview,
   withPrismicUnpublishedPreview,
-  PrismicRepositoryConfig,
-  PrismicUnpublishedRepositoryConfig,
 } from '../src'
 import { onClientEntry } from '../src/on-client-entry'
 import { createPrismicAPIDocumentNodeInput } from './__testutils__/createPrismicAPIDocumentNodeInput'
@@ -54,7 +54,6 @@ test.before(() => {
   })
   server.listen({ onUnhandledRequest: 'error' })
   globalThis.__PATH_PREFIX__ = 'https://example.com'
-  // console.error = sinon.stub()
 })
 test.beforeEach(() => {
   clearAllCookies()
@@ -67,8 +66,8 @@ test.after(() => {
 
 const createRepositoryConfigs = (
   pluginOptions: PluginOptions,
-): PrismicUnpublishedRepositoryConfig[] => {
-  const baseConfigs: PrismicRepositoryConfig[] = [
+): PrismicUnpublishedRepositoryConfigs => {
+  const baseConfigs: PrismicRepositoryConfigs = [
     {
       repositoryName: pluginOptions.repositoryName,
       linkResolver: (doc): string => `/${doc.uid}`,
@@ -115,7 +114,7 @@ const Page = <TProps extends UnknownRecord = UnknownRecord>(
 
 const createTree = (
   pageProps: gatsby.PageProps,
-  repositoryConfigs: PrismicUnpublishedRepositoryConfig[],
+  repositoryConfigs: PrismicUnpublishedRepositoryConfigs,
 ) => {
   const WrappedPage = withPrismicUnpublishedPreview(
     NotFoundPage,

--- a/packages/test-site/src/pages/404.tsx
+++ b/packages/test-site/src/pages/404.tsx
@@ -1,54 +1,11 @@
 import * as React from 'react'
-import { PageProps } from 'gatsby'
-import {
-  componentResolverFromMap,
-  WithPrismicPreviewProps,
-  withPrismicUnpublishedPreview,
-} from 'gatsby-plugin-prismic-previews'
-import * as prismic from 'ts-prismic'
+import { withPrismicUnpublishedPreview } from 'gatsby-plugin-prismic-previews'
 
-import { linkResolver } from '../linkResolver'
+import { unpublishedRepositoryConfigs } from '../prismicUnpublishedPreviews'
 
-import KitchenSinkPage from '../pages/{PrismicPrefixKitchenSink.uid}'
-
-const repoName = process.env.GATSBY_PRISMIC_REPOSITORY_NAME as string
-
-const NotFoundPage = () => '404 Not Found'
-
-// const NotFoundPage = (): string => '404'
+const NotFoundPage = () => <>404 Not Found</>
 
 export default withPrismicUnpublishedPreview(
   NotFoundPage,
-  { [repoName]: { linkResolver } },
-  {
-    componentResolver: componentResolverFromMap({
-      kitchen_sink: KitchenSinkPage,
-    }),
-  },
-  // {
-  //   componentResolver: <P extends PageProps>(
-  //     docs: prismic.Document[],
-  //   ): React.ComponentType<P> | void => {
-  //     switch (docs[0].type) {
-  //       case 'kitchen_sink':
-  //         return KitchenSinkPage
-  //     }
-  //   },
-  //   dataResolver: (nodes) => {
-  //     return nodes[0]
-  //   },
-  // },
-  // {
-  //   componentRenderer: (
-  //     docs: prismic.Document[],
-  //     props: PageProps & WithPrismicPreviewProps,
-  //   ): React.ReactNode | void => {
-  //     const doc = docs[0]
-
-  //     switch (doc.type) {
-  //       case 'kitchen_sink':
-  //         return <KitchenSinkPage {...props} />
-  //     }
-  //   },
-  // },
+  unpublishedRepositoryConfigs,
 )

--- a/packages/test-site/src/pages/index.tsx
+++ b/packages/test-site/src/pages/index.tsx
@@ -7,7 +7,7 @@ import {
   WithPrismicPreviewProps,
 } from 'gatsby-plugin-prismic-previews'
 
-import { linkResolver } from '../linkResolver'
+import { repositoryConfigs } from '../prismicPreviews'
 
 const repoName = process.env.GATSBY_PRISMIC_REPOSITORY_NAME as string
 
@@ -43,9 +43,7 @@ const HomePage = ({
   )
 }
 
-export default withPrismicPreview(HomePage, {
-  [repoName]: { linkResolver },
-})
+export default withPrismicPreview(HomePage, repositoryConfigs)
 
 export const query = graphql`
   {

--- a/packages/test-site/src/pages/preview.tsx
+++ b/packages/test-site/src/pages/preview.tsx
@@ -5,9 +5,7 @@ import {
   WithPrismicPreviewResolverProps,
 } from 'gatsby-plugin-prismic-previews'
 
-import { linkResolver } from '../linkResolver'
-
-const repoName = process.env.GATSBY_PRISMIC_REPOSITORY_NAME as string
+import { repositoryConfigs } from '../prismicPreviews'
 
 type PreviewPageProps = PageProps & WithPrismicPreviewResolverProps
 
@@ -21,6 +19,4 @@ const PreviewPage = (props: PreviewPageProps): JSX.Element => {
   )
 }
 
-export default withPrismicPreviewResolver(PreviewPage, {
-  [repoName]: { linkResolver },
-})
+export default withPrismicPreviewResolver(PreviewPage, repositoryConfigs)

--- a/packages/test-site/src/pages/{PrismicPrefixKitchenSink.uid}.tsx
+++ b/packages/test-site/src/pages/{PrismicPrefixKitchenSink.uid}.tsx
@@ -5,9 +5,7 @@ import {
   WithPrismicPreviewProps,
 } from 'gatsby-plugin-prismic-previews'
 
-import { linkResolver } from '../linkResolver'
-
-const repoName = process.env.GATSBY_PRISMIC_REPOSITORY_NAME as string
+import { repositoryConfigs } from '../prismicPreviews'
 
 const KitchenSinkPage = (
   props: PageProps<Record<string, any>> &
@@ -97,9 +95,7 @@ const KitchenSinkPage = (
   )
 }
 
-export default withPrismicPreview(KitchenSinkPage, {
-  [repoName]: { linkResolver },
-})
+export default withPrismicPreview(KitchenSinkPage, repositoryConfigs)
 
 export const query = graphql`
   query($uid: String!) {

--- a/packages/test-site/src/prismicPreviews.ts
+++ b/packages/test-site/src/prismicPreviews.ts
@@ -1,0 +1,28 @@
+/**
+ * This file contains configuration for `gatsby-plugin-prismic-previews` to
+ * support preview sessions from Prismic.
+ *
+ * @see https://github.com/angeloashmore/gatsby-source-prismic/tree/alpha/packages/gatsby-plugin-prismic-previews
+ */
+
+import { PrismicRepositoryConfigs } from 'gatsby-plugin-prismic-previews'
+
+import { linkResolver } from './linkResolver'
+
+/**
+ * Prismic preview configuration for each repository in your app. This set of
+ * configuration objects will be used with the `withPrismicPreview` and
+ * `withPrismicUnpublishedPreview` higher order components.
+ *
+ * If your app needs to support multiple Prismic repositories, add each of
+ * their own configuration objects here as additional elements.
+ *
+ * @see https://github.com/angeloashmore/gatsby-source-prismic/tree/alpha/packages/gatsby-plugin-prismic-previews#content-pages-and-templates
+ */
+export const repositoryConfigs: PrismicRepositoryConfigs = [
+  {
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    repositoryName: process.env.GATSBY_PRISMIC_REPOSITORY_NAME!,
+    linkResolver,
+  },
+]

--- a/packages/test-site/src/prismicUnpublishedPreviews.ts
+++ b/packages/test-site/src/prismicUnpublishedPreviews.ts
@@ -1,0 +1,36 @@
+/**
+ * This file contains configuration for `gatsby-plugin-prismic-previews` to
+ * support preview sessions from Prismic with unpublished documents.
+ *
+ * @see https://github.com/angeloashmore/gatsby-source-prismic/tree/alpha/packages/gatsby-plugin-prismic-previews
+ */
+
+import {
+  componentResolverFromMap,
+  PrismicUnpublishedRepositoryConfigs,
+} from 'gatsby-plugin-prismic-previews'
+
+import { linkResolver } from './linkResolver'
+
+import KitchenSinkTemplate from './pages/{PrismicPrefixKitchenSink.uid}'
+
+/**
+ * Prismic preview configuration for each repository in your app. This set of
+ * configuration objects will be used with the `withPrismicUnpublishedPreview`
+ * higher order component.
+ *
+ * If your app needs to support multiple Prismic repositories, add each of
+ * their own configuration objects here as additional elements.
+ *
+ * @see https://github.com/angeloashmore/gatsby-source-prismic/tree/alpha/packages/gatsby-plugin-prismic-previews#404-not-found-page
+ */
+export const unpublishedRepositoryConfigs: PrismicUnpublishedRepositoryConfigs = [
+  {
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    repositoryName: process.env.GATSBY_PRISMIC_REPOSITORY_NAME!,
+    linkResolver,
+    componentResolver: componentResolverFromMap({
+      kitchen_sink: KitchenSinkTemplate,
+    }),
+  },
+]

--- a/starters/gatsby-starter-prismic-typescript/package.json
+++ b/starters/gatsby-starter-prismic-typescript/package.json
@@ -29,7 +29,7 @@
   "dependencies": {
     "gatsby": "^3.1.2",
     "gatsby-plugin-catch-links": "^3.1.0",
-    "gatsby-plugin-prismic-previews": "^4.0.0-alpha.4",
+    "gatsby-plugin-prismic-previews": "^4.0.0-alpha.5",
     "gatsby-plugin-react-helmet-async": "^1.2.0",
     "gatsby-source-prismic": "^4.0.0-alpha.3",
     "react": "^17.0.2",

--- a/starters/gatsby-starter-prismic-typescript/src/pages/404.tsx
+++ b/starters/gatsby-starter-prismic-typescript/src/pages/404.tsx
@@ -12,7 +12,7 @@
 import * as React from 'react'
 import { withPrismicUnpublishedPreview } from 'gatsby-plugin-prismic-previews'
 
-import * as prismicPreviews from '../prismicPreviews'
+import { unpublishedRepositoryConfigs } from '../prismicUnpublishedPreviews'
 
 import { Layout } from '../components/Layout'
 import { SEO } from '../components/SEO'
@@ -37,6 +37,5 @@ const NotFoundPage = () => (
  */
 export default withPrismicUnpublishedPreview(
   NotFoundPage,
-  prismicPreviews.repositoryConfigs,
-  prismicPreviews.unpublishedPreviewConfig,
+  unpublishedRepositoryConfigs,
 )

--- a/starters/gatsby-starter-prismic-typescript/src/pages/preview.tsx
+++ b/starters/gatsby-starter-prismic-typescript/src/pages/preview.tsx
@@ -15,8 +15,7 @@ import {
   withPrismicPreviewResolver,
   WithPrismicPreviewResolverProps,
 } from 'gatsby-plugin-prismic-previews'
-
-import * as prismicPreviews from '../prismicPreviews'
+import { repositoryConfigs } from '../prismicPreviews'
 
 type PreviewPageProps = PageProps & WithPrismicPreviewResolverProps
 
@@ -38,7 +37,4 @@ const PreviewPage = ({ isPrismicPreview }: PreviewPageProps) => {
  *
  * @see https://github.com/angeloashmore/gatsby-source-prismic/blob/alpha/packages/gatsby-plugin-prismic-previews/docs/api-withPrismicPreviewResolver.md
  */
-export default withPrismicPreviewResolver(
-  PreviewPage,
-  prismicPreviews.repositoryConfigs,
-)
+export default withPrismicPreviewResolver(PreviewPage, repositoryConfigs)

--- a/starters/gatsby-starter-prismic-typescript/src/pages/{PrismicPage.url}.tsx
+++ b/starters/gatsby-starter-prismic-typescript/src/pages/{PrismicPage.url}.tsx
@@ -18,7 +18,7 @@ import {
 } from 'gatsby-plugin-prismic-previews'
 
 import { PageTemplateQuery } from '../types.generated'
-import * as prismicPreviews from '../prismicPreviews'
+import { repositoryConfigs } from '../prismicPreviews'
 
 import { Layout } from '../components/Layout'
 import { SEO } from '../components/SEO'
@@ -48,10 +48,7 @@ const PageTemplate = ({ data }: PageTemplateProps) => (
  *
  * @see https://github.com/angeloashmore/gatsby-source-prismic/blob/alpha/packages/gatsby-plugin-prismic-previews/docs/api-withPrismicPreview.md
  */
-export default withPrismicPreview(
-  PageTemplate,
-  prismicPreviews.repositoryConfigs,
-)
+export default withPrismicPreview(PageTemplate, repositoryConfigs)
 
 export const query = graphql`
   query PageTemplate($id: String!) {

--- a/starters/gatsby-starter-prismic-typescript/src/prismicUnpublishedPreviews.ts
+++ b/starters/gatsby-starter-prismic-typescript/src/prismicUnpublishedPreviews.ts
@@ -1,0 +1,35 @@
+/**
+ * This file contains configuration for `gatsby-plugin-prismic-previews` to
+ * support preview sessions from Prismic with unpublished documents.
+ *
+ * @see https://github.com/angeloashmore/gatsby-source-prismic/tree/alpha/packages/gatsby-plugin-prismic-previews
+ */
+
+import {
+  componentResolverFromMap,
+  PrismicUnpublishedRepositoryConfigs,
+} from 'gatsby-plugin-prismic-previews'
+
+import { linkResolver } from './linkResolver'
+
+import PageTemplate from './pages/{PrismicPage.url}'
+
+/**
+ * Prismic preview configuration for each repository in your app. This set of
+ * configuration objects will be used with the `withPrismicUnpublishedPreview`
+ * higher order component.
+ *
+ * If your app needs to support multiple Prismic repositories, add each of
+ * their own configuration objects here as additional elements.
+ *
+ * @see https://github.com/angeloashmore/gatsby-source-prismic/tree/alpha/packages/gatsby-plugin-prismic-previews#404-not-found-page
+ */
+export const unpublishedRepositoryConfigs: PrismicUnpublishedRepositoryConfigs = [
+  {
+    repositoryName: process.env.GATSBY_PRISMIC_REPOSITORY_NAME!,
+    linkResolver,
+    componentResolver: componentResolverFromMap({
+      page: PageTemplate,
+    }),
+  },
+]

--- a/starters/gatsby-starter-prismic-typescript/yarn.lock
+++ b/starters/gatsby-starter-prismic-typescript/yarn.lock
@@ -5798,10 +5798,10 @@ gatsby-plugin-page-creator@^3.1.0:
     globby "^11.0.2"
     lodash "^4.17.21"
 
-gatsby-plugin-prismic-previews@^4.0.0-alpha.4:
-  version "4.0.0-alpha.4"
-  resolved "https://registry.yarnpkg.com/gatsby-plugin-prismic-previews/-/gatsby-plugin-prismic-previews-4.0.0-alpha.4.tgz#a79dbee32a29f47da92f5fad2c1d3de5c6063222"
-  integrity sha512-IqTMHYFDZeZ3zATWxS6IChU65imS/qssEHAujodE7+ktctC6vWPaObvXSPw6Bw0cUjiLbzGbeQHJAhyZ65TU2Q==
+gatsby-plugin-prismic-previews@^4.0.0-alpha.5:
+  version "4.0.0-alpha.5"
+  resolved "https://registry.yarnpkg.com/gatsby-plugin-prismic-previews/-/gatsby-plugin-prismic-previews-4.0.0-alpha.5.tgz#17bd88140f6b3d79475648a0b93a7335cb7512e3"
+  integrity sha512-zTx2lkchdswU9MvfDxJAm1aMWBPVND0AUKgOu4pUGl39fVUofNX6xWBJeO9MfI1dFVId5ajW5j4B+WZVOvx5HQ==
   dependencies:
     "@reach/dialog" "^0.15.0"
     camel-case "^4.1.2"

--- a/starters/gatsby-starter-prismic/package.json
+++ b/starters/gatsby-starter-prismic/package.json
@@ -28,7 +28,7 @@
   "dependencies": {
     "gatsby": "^3.1.2",
     "gatsby-plugin-catch-links": "^3.1.0",
-    "gatsby-plugin-prismic-previews": "^4.0.0-alpha.0",
+    "gatsby-plugin-prismic-previews": "^4.0.0-alpha.5",
     "gatsby-plugin-react-helmet-async": "^1.2.0",
     "gatsby-source-prismic": "^4.0.0-alpha.2",
     "react": "^17.0.2",

--- a/starters/gatsby-starter-prismic/src/pages/404.js
+++ b/starters/gatsby-starter-prismic/src/pages/404.js
@@ -1,12 +1,7 @@
 import * as React from 'react'
-import {
-  withPrismicUnpublishedPreview,
-  componentResolverFromMap,
-} from 'gatsby-plugin-prismic-previews'
+import { withPrismicUnpublishedPreview } from 'gatsby-plugin-prismic-previews'
 
-import { linkResolver } from '../linkResolver'
-
-import PageTemplate from './{PrismicPage.url}'
+import { unpublishedRepositoryConfigs } from '../prismicUnpublishedPreviews'
 
 import { Layout } from '../components/Layout'
 import { SEO } from '../components/SEO'
@@ -21,12 +16,5 @@ const NotFoundPage = () => (
 
 export default withPrismicUnpublishedPreview(
   NotFoundPage,
-  {
-    [process.env.GATSBY_PRISMIC_REPOSITORY_NAME]: { linkResolver },
-  },
-  {
-    componentResolver: componentResolverFromMap({
-      page: PageTemplate,
-    }),
-  },
+  unpublishedRepositoryConfigs,
 )

--- a/starters/gatsby-starter-prismic/src/pages/preview.js
+++ b/starters/gatsby-starter-prismic/src/pages/preview.js
@@ -2,7 +2,7 @@ import * as React from 'react'
 import { navigate } from 'gatsby'
 import { withPrismicPreviewResolver } from 'gatsby-plugin-prismic-previews'
 
-import { linkResolver } from '../linkResolver'
+import { repositoryConfigs } from '../prismicPreviews'
 
 const PreviewPage = ({ isPrismicPreview }) => {
   React.useEffect(() => {
@@ -16,6 +16,4 @@ const PreviewPage = ({ isPrismicPreview }) => {
   return null
 }
 
-export default withPrismicPreviewResolver(PreviewPage, {
-  [process.env.GATSBY_PRISMIC_REPOSITORY_NAME]: { linkResolver },
-})
+export default withPrismicPreviewResolver(PreviewPage, repositoryConfigs)

--- a/starters/gatsby-starter-prismic/src/pages/{PrismicPage.url}.js
+++ b/starters/gatsby-starter-prismic/src/pages/{PrismicPage.url}.js
@@ -2,7 +2,7 @@ import * as React from 'react'
 import { graphql } from 'gatsby'
 import { withPrismicPreview } from 'gatsby-plugin-prismic-previews'
 
-import { linkResolver } from '../linkResolver'
+import { repositoryConfigs } from '../prismicPreviews'
 
 import { Layout } from '../components/Layout'
 import { SEO } from '../components/SEO'
@@ -21,9 +21,7 @@ const PageTemplate = ({ data }) => (
   </Layout>
 )
 
-export default withPrismicPreview(PageTemplate, {
-  [process.env.GATSBY_PRISMIC_REPOSITORY_NAME]: { linkResolver },
-})
+export default withPrismicPreview(PageTemplate, repositoryConfigs)
 
 export const query = graphql`
   query PageTemplate($id: String!) {

--- a/starters/gatsby-starter-prismic/src/prismicPreviews.js
+++ b/starters/gatsby-starter-prismic/src/prismicPreviews.js
@@ -5,8 +5,6 @@
  * @see https://github.com/angeloashmore/gatsby-source-prismic/tree/alpha/packages/gatsby-plugin-prismic-previews
  */
 
-import { PrismicRepositoryConfigs } from 'gatsby-plugin-prismic-previews'
-
 import { linkResolver } from './linkResolver'
 
 /**
@@ -19,9 +17,9 @@ import { linkResolver } from './linkResolver'
  *
  * @see https://github.com/angeloashmore/gatsby-source-prismic/tree/alpha/packages/gatsby-plugin-prismic-previews#content-pages-and-templates
  */
-export const repositoryConfigs: PrismicRepositoryConfigs = [
+export const repositoryConfigs = [
   {
-    repositoryName: process.env.GATSBY_PRISMIC_REPOSITORY_NAME!,
+    repositoryName: process.env.GATSBY_PRISMIC_REPOSITORY_NAME,
     linkResolver,
   },
 ]

--- a/starters/gatsby-starter-prismic/src/prismicUnpublishedPreviews.js
+++ b/starters/gatsby-starter-prismic/src/prismicUnpublishedPreviews.js
@@ -1,0 +1,32 @@
+/**
+ * This file contains configuration for `gatsby-plugin-prismic-previews` to
+ * support preview sessions from Prismic with unpublished documents.
+ *
+ * @see https://github.com/angeloashmore/gatsby-source-prismic/tree/alpha/packages/gatsby-plugin-prismic-previews
+ */
+
+import { componentResolverFromMap } from 'gatsby-plugin-prismic-previews'
+
+import { linkResolver } from './linkResolver'
+
+import PageTemplate from './pages/{PrismicPage.url}'
+
+/**
+ * Prismic preview configuration for each repository in your app. This set of
+ * configuration objects will be used with the `withPrismicUnpublishedPreview`
+ * higher order component.
+ *
+ * If your app needs to support multiple Prismic repositories, add each of
+ * their own configuration objects here as additional elements.
+ *
+ * @see https://github.com/angeloashmore/gatsby-source-prismic/tree/alpha/packages/gatsby-plugin-prismic-previews#404-not-found-page
+ */
+export const unpublishedRepositoryConfigs = [
+  {
+    repositoryName: process.env.GATSBY_PRISMIC_REPOSITORY_NAME,
+    linkResolver,
+    componentResolver: componentResolverFromMap({
+      page: PageTemplate,
+    }),
+  },
+]

--- a/starters/gatsby-starter-prismic/yarn.lock
+++ b/starters/gatsby-starter-prismic/yarn.lock
@@ -1310,34 +1310,33 @@
   resolved "https://registry.yarnpkg.com/@prismicio/richtext/-/richtext-1.1.0.tgz#c8769c3d953ae42854a2aba951e3b2121682b8c7"
   integrity sha512-925JuFiZiIkwu9jmlR9O/U8xCSZk/Y6BQDXKpavoVsKo+n90ml1hGdtWkglIupX+ITQO1ZINyDgUgiY1oG9dsA==
 
-"@reach/dialog@^0.13.2":
-  version "0.13.2"
-  resolved "https://registry.yarnpkg.com/@reach/dialog/-/dialog-0.13.2.tgz#edbb8800f20e795c70b455b34999c6355b61c154"
-  integrity sha512-DOl7REyfrC3v6ugZtuiZs3pNr4ctRFBPU53AXph1kS5qH+3HxW2/Nq231Wg3ck+FQsZI+Ch4DeT0af52nbIaCg==
+"@reach/dialog@^0.15.0":
+  version "0.15.0"
+  resolved "https://registry.yarnpkg.com/@reach/dialog/-/dialog-0.15.0.tgz#e1dd2d30ea060a65fc8810b9a7e16f1a5bc64d69"
+  integrity sha512-ivZr4ukUcEr/tU1wYpHJt0XZF1kZunaZmNeQwIqaVrjpvwIVbWJtEmDvXDSuUYiNOxJ7L9iCt4nrN8sZhf78XA==
   dependencies:
-    "@reach/portal" "0.13.2"
-    "@reach/utils" "0.13.2"
+    "@reach/portal" "0.15.0"
+    "@reach/utils" "0.15.0"
     prop-types "^15.7.2"
     react-focus-lock "^2.5.0"
     react-remove-scroll "^2.4.1"
     tslib "^2.1.0"
 
-"@reach/portal@0.13.2":
-  version "0.13.2"
-  resolved "https://registry.yarnpkg.com/@reach/portal/-/portal-0.13.2.tgz#6f2a6f4afc14894bde9c6435667bb9b660887ed9"
-  integrity sha512-g74BnCdtuTGthzzHn2cWW+bcyIYb0iIE/yRsm89i8oNzNgpopbkh9UY8TPbhNlys52h7U60s4kpRTmcq+JqsTA==
+"@reach/portal@0.15.0":
+  version "0.15.0"
+  resolved "https://registry.yarnpkg.com/@reach/portal/-/portal-0.15.0.tgz#b137582a1ecc4e04c60ce9a9c672dd2d23a2f1cc"
+  integrity sha512-Aulqjk/PIRu+R7yhINYAAYfYh++ZdC30qwHDWDtGk2cmTEJT7m9AlvBX+W7T+Q3Ux6Wy5f37eV+TTGid1CcjFw==
   dependencies:
-    "@reach/utils" "0.13.2"
+    "@reach/utils" "0.15.0"
     tslib "^2.1.0"
 
-"@reach/utils@0.13.2":
-  version "0.13.2"
-  resolved "https://registry.yarnpkg.com/@reach/utils/-/utils-0.13.2.tgz#87e8fef8ebfe583fa48250238a1a3ed03189fcc8"
-  integrity sha512-3ir6cN60zvUrwjOJu7C6jec/samqAeyAB12ZADK+qjnmQPdzSYldrFWwDVV5H0WkhbYXR3uh+eImu13hCetNPQ==
+"@reach/utils@0.15.0":
+  version "0.15.0"
+  resolved "https://registry.yarnpkg.com/@reach/utils/-/utils-0.15.0.tgz#5b183d668f9bb900b2dec7a33c028a2a828d27b2"
+  integrity sha512-JHHN7T5ucFiuQbqkgv8ECbRWKfRiJxrO/xHR3fHf+f2C7mVs/KkJHhYtovS1iEapR4silygX9PY0+QUmHPOTYw==
   dependencies:
-    "@types/warning" "^3.0.0"
+    tiny-warning "^1.0.3"
     tslib "^2.1.0"
-    warning "^4.0.3"
 
 "@sideway/address@^4.1.0":
   version "4.1.1"
@@ -1668,11 +1667,6 @@
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/@types/unist/-/unist-2.0.3.tgz#9c088679876f374eb5983f150d4787aa6fb32d7e"
   integrity sha512-FvUupuM3rlRsRtCN+fDudtmytGO6iHJuuRKS1Ss0pG5z8oX0diNEw94UEL7hgDbpN94rgaK5R7sWm6RrSkZuAQ==
-
-"@types/warning@^3.0.0":
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/@types/warning/-/warning-3.0.0.tgz#0d2501268ad8f9962b740d387c4654f5f8e23e52"
-  integrity sha1-DSUBJorY+ZYrdA04fEZU9fjiPlI=
 
 "@types/websocket@1.0.2":
   version "1.0.2"
@@ -5020,12 +5014,12 @@ gatsby-plugin-page-creator@^3.1.0:
     globby "^11.0.2"
     lodash "^4.17.21"
 
-gatsby-plugin-prismic-previews@^4.0.0-alpha.0:
-  version "4.0.0-alpha.0"
-  resolved "https://registry.yarnpkg.com/gatsby-plugin-prismic-previews/-/gatsby-plugin-prismic-previews-4.0.0-alpha.0.tgz#3fb002921169c952a921bd93c1b272e35a642d7f"
-  integrity sha512-ILDzUJzoGo1el9atQssZ8KSUQdqqJHxWuL5h2+Rr9yASgdHBR5bq2WNqUw1VCSGUA/+gLkY5ryRwK3mzj8yqmA==
+gatsby-plugin-prismic-previews@^4.0.0-alpha.5:
+  version "4.0.0-alpha.5"
+  resolved "https://registry.yarnpkg.com/gatsby-plugin-prismic-previews/-/gatsby-plugin-prismic-previews-4.0.0-alpha.5.tgz#17bd88140f6b3d79475648a0b93a7335cb7512e3"
+  integrity sha512-zTx2lkchdswU9MvfDxJAm1aMWBPVND0AUKgOu4pUGl39fVUofNX6xWBJeO9MfI1dFVId5ajW5j4B+WZVOvx5HQ==
   dependencies:
-    "@reach/dialog" "^0.13.2"
+    "@reach/dialog" "^0.15.0"
     camel-case "^4.1.2"
     chalk "^4.1.0"
     clsx "^1.1.1"
@@ -10401,6 +10395,11 @@ tiny-hashes@^1.0.1:
   resolved "https://registry.yarnpkg.com/tiny-hashes/-/tiny-hashes-1.0.1.tgz#ddbe9060312ddb4efe0a174bb3a27e1331c425a1"
   integrity sha512-knIN5zj4fl7kW4EBU5sLP20DWUvi/rVouvJezV0UAym2DkQaqm365Nyc8F3QEiOvunNDMxR8UhcXd1d5g+Wg1g==
 
+tiny-warning@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/tiny-warning/-/tiny-warning-1.0.3.tgz#94a30db453df4c643d0fd566060d60a875d84754"
+  integrity sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA==
+
 tmp@^0.0.33:
   version "0.0.33"
   resolved "https://registry.yarnpkg.com/tmp/-/tmp-0.0.33.tgz#6d34335889768d21b2bcda0aa277ced3b1bfadf9"
@@ -10988,13 +10987,6 @@ vfile@^4.0.0:
     is-buffer "^2.0.0"
     unist-util-stringify-position "^2.0.0"
     vfile-message "^2.0.0"
-
-warning@^4.0.3:
-  version "4.0.3"
-  resolved "https://registry.yarnpkg.com/warning/-/warning-4.0.3.tgz#16e9e077eb8a86d6af7d64aa1e05fd85b4678ca3"
-  integrity sha512-rpJyN222KWIvHJ/F53XSZv0Zl/accqHR8et1kpaMTD/fLCRxtV8iX8czMzY7sVZupTI3zcUTg8eycS2kNF9l6w==
-  dependencies:
-    loose-envify "^1.0.0"
 
 watchpack@^2.0.0:
   version "2.1.1"


### PR DESCRIPTION
This PR changes the preview configuration API to a more straightforward syntax. Rather than provide objects with repository names as keys, the configuration is now done by passing an array of objects.

This eliminates the need to include special syntax when using variables as object keys.

Before:
```javascript
export default withPrismicPreview(PageTemplate, {
  [process.env.GATSBY_PRISMIC_MAIN_REPOSITORY_NAME]: {
    linkResolver: mainLinkResolver,
  },
  [process.env.GATSBY_PRISMIC_SECONDARY_REPOSITORY_NAME]: {
    linkResolver: secondaryLinkResolver,
  },
})
```

After:
```javascript
export default withPrismicPreview(PageTemplate, [
  {
    repositoryName: process.env.GATSBY_PRISMIC_MAIN_REPOSITORY_NAME,
    linkResolver: mainLinkResolver,
  },
  {
    repositoryName: process.env.GATSBY_PRISMIC_SECONDARY_REPOSITORY_NAME,
    linkResolver: secondaryLinkResolver,
  },
])
```

Although it is a little more verbose, the clarity is worth it.

This could later be refined to allow users to pass a single object rather than array if only one repository is needed (which is most cases).

```javascript
export default withPrismicPreview(PageTemplate, {
  repositoryName: process.env.GATSBY_PRISMIC_MAIN_REPOSITORY_NAME,
  linkResolver: mainLinkResolver,
})
```