### PR TITLE
fix: retain existing Imgix URL parameters on images

### DIFF
--- a/packages/gatsby-plugin-prismic-previews/package.json
+++ b/packages/gatsby-plugin-prismic-previews/package.json
@@ -32,7 +32,7 @@
     "prismic"
   ],
   "dependencies": {
-    "@imgix/gatsby": "^1.6.3",
+    "@imgix/gatsby": "^1.6.6",
     "@reach/dialog": "^0.15.0",
     "camel-case": "^4.1.2",
     "chalk": "^4.1.1",

--- a/packages/gatsby-source-prismic/package.json
+++ b/packages/gatsby-source-prismic/package.json
@@ -29,7 +29,7 @@
     "prismic"
   ],
   "dependencies": {
-    "@imgix/gatsby": "^1.6.3",
+    "@imgix/gatsby": "^1.6.6",
     "camel-case": "^4.1.2",
     "fp-ts": "^2.10.5",
     "gatsby-node-helpers": "^1.2.1",

--- a/packages/gatsby-source-prismic/src/builders/buildImageBaseFieldConfigMap.ts
+++ b/packages/gatsby-source-prismic/src/builders/buildImageBaseFieldConfigMap.ts
@@ -36,6 +36,59 @@ const resolveHeight = (source: PrismicAPIImageField): number | undefined =>
   source.dimensions?.height
 
 /**
+ * The minimum required GraphQL argument properties for an `@imgix/gatsby` field.
+ */
+interface ImgixGatsbyFieldArgsLike {
+  imgixParams: Record<string, string | number | boolean>
+}
+
+/**
+ * Modifies an `@imgix/gatsby` GraphQL field config to retain existing Imgix
+ * parameters set on the source URL.
+ *
+ * This is needed if the source URL contains parameters like `rect` (crops an
+ * image). Without this config enhancer, the `rect` parameter would be removed.
+ *
+ * @param fieldConfig GraphQL field config object to be enhanced.
+ *
+ * @returns `fieldConfig` with the ability to retain existing Imgix parameters on the source URL.
+ */
+const withExistingURLImgixParameters = <
+  TContext,
+  TArgs extends ImgixGatsbyFieldArgsLike,
+>(
+  fieldConfig: gqlc.ObjectTypeComposerFieldConfigAsObjectDefinition<
+    PrismicAPIImageField,
+    TContext,
+    TArgs
+  >,
+): typeof fieldConfig => ({
+  ...fieldConfig,
+  resolve: (source, args, ...rest) => {
+    if (!fieldConfig.resolve || !source.url) {
+      return null
+    }
+
+    const url = new URL(source.url)
+
+    const existingImgixParams: ImgixGatsbyFieldArgsLike['imgixParams'] = {}
+    for (const [key, value] of url.searchParams.entries()) {
+      existingImgixParams[key] = value
+    }
+
+    const argsWithExistingImgixParams = {
+      ...args,
+      imgixParams: {
+        ...existingImgixParams,
+        ...args.imgixParams,
+      },
+    }
+
+    return fieldConfig.resolve(source, argsWithExistingImgixParams, ...rest)
+  },
+})
+
+/**
  * Builds a GraphQL field configuration object to be used as part of another
  * Image field GraphQL configuration object. For example, this base
  * configuration object could be added to a config for the thumbnails of an
@@ -61,12 +114,20 @@ export const buildImageBaseFieldConfigMap: RTE.ReaderTaskEither<
       }),
     ),
   ),
-  RTE.bind('urlField', (scope) => RTE.right(scope.imgixTypes.fields.url)),
-  RTE.bind('fixedField', (scope) => RTE.right(scope.imgixTypes.fields.fixed)),
-  RTE.bind('fluidField', (scope) => RTE.right(scope.imgixTypes.fields.fluid)),
+  RTE.bind('urlField', (scope) =>
+    RTE.right(withExistingURLImgixParameters(scope.imgixTypes.fields.url)),
+  ),
+  RTE.bind('fixedField', (scope) =>
+    RTE.right(withExistingURLImgixParameters(scope.imgixTypes.fields.fixed)),
+  ),
+  RTE.bind('fluidField', (scope) =>
+    RTE.right(withExistingURLImgixParameters(scope.imgixTypes.fields.fluid)),
+  ),
   RTE.bind('gatsbyImageDataField', (scope) =>
     pipe(
-      RTE.right(scope.imgixTypes.fields.gatsbyImageData),
+      RTE.right(
+        withExistingURLImgixParameters(scope.imgixTypes.fields.gatsbyImageData),
+      ),
       // This field is 'JSON!' by default (i.e. non-nullable). If an image is
       // not set in Prismic, however, this field throws a GraphQL error saying a
       // non-nullable field was returned a null value. This should not happen

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "module": "CommonJS",
     "target": "ESNext",
-    "lib": ["DOM", "ESNext"],
+    "lib": ["DOM", "DOM.Iterable", "ESNext"],
     "importHelpers": true,
     "sourceMap": true,
     "strict": true,

--- a/yarn.lock
+++ b/yarn.lock
@@ -1647,10 +1647,10 @@
   resolved "https://registry.yarnpkg.com/@iarna/toml/-/toml-2.2.5.tgz#b32366c89b43c6f8cefbdefac778b9c828e3ba8c"
   integrity sha512-trnsAYxU3xnS1gPHPyU961coFyLkh4gAD/0zQ5mymY4yOZ+CYvsPqUbOFSw0aDM4y0tV7tiFxL/1XfXPNC6IPg==
 
-"@imgix/gatsby@^1.6.3":
-  version "1.6.3"
-  resolved "https://registry.yarnpkg.com/@imgix/gatsby/-/gatsby-1.6.3.tgz#d8ae1032767d7aa3488032b63f5492fb8cca8901"
-  integrity sha512-ueK0RK58M/66Z1pCM6UmRleBFshGJRkQmaNjYxGs5C1cQ8rrnEL5Lg8pNf0d2Vr2EuFhvgnI3x4FVRozXuMVGg==
+"@imgix/gatsby@^1.6.6":
+  version "1.6.6"
+  resolved "https://registry.yarnpkg.com/@imgix/gatsby/-/gatsby-1.6.6.tgz#c38abf35cd39b22f53cc020e6c471b0d382e9782"
+  integrity sha512-bngboBzagVgEfDieJBrSRoyLMVqXm4rOh0tAJINdGdNF2bc6v1YO03JV2FZtM9ueo1UOI+lBLeb5zUJ0qAobNg==
   dependencies:
     "@imgix/js-core" "3.1.3"
     camel-case "^4.1.2"


### PR DESCRIPTION
Ensures existing Imgix URL parameters on image URLs are retained after `gatsby-image` and `gatsby-plugin-image` transformations.

Currently blocked by an issue described in this comment: https://github.com/imgix/gatsby/issues/122#issuecomment-846256825